### PR TITLE
Back & Front - remove isStart for status action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,7 +68,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -81,6 +81,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: "[Release] Mirror push to gitlab"
 
 on:
-  push:
-    branches: [ "main" ]
+  #  push:
+  #    branches: [ "main" ]
   release:
     types: [ published ]
   workflow_dispatch:
@@ -19,20 +19,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      #      - name: Get frontend version
-      #        uses: avides/actions-project-version-check@v1.4.0
-      #        id: frontend_version
-      #        with:
-      #          token: ${{ secrets.GITHUB_TOKEN }}
-      #          file-to-check: frontend/package.json
-      #          only-return-version: true
-      #
-      #      - name: Upload Frontend sourcemaps
-      #        uses: ./.github/actions/upload-sourcemaps
-      #        with:
-      #          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      #          VERSION: ${{ steps.frontend_version.outputs.version }}
-      #test
+      - name: Get frontend version
+        uses: avides/actions-project-version-check@v1.4.0
+        id: frontend_version
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          file-to-check: frontend/package.json
+          only-return-version: true
+
+      - name: Upload Frontend sourcemaps
+        uses: ./.github/actions/upload-sourcemaps
+        with:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VERSION: ${{ steps.frontend_version.outputs.version }}
+
       - uses: yesolutions/mirror-action@master
         with:
           REMOTE: https://gitlab-sml.din.developpement-durable.gouv.fr/rapportnav-v2/rapportnav_v2.git

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/nav/action/ActionStatusEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/nav/action/ActionStatusEntity.kt
@@ -12,7 +12,6 @@ data class ActionStatusEntity(
     val startDateTimeUtc: ZonedDateTime,
     val status: ActionStatusType,
     val reason: ActionStatusReason? = null,
-    val isStart: Boolean,
     val observations: String? = null,
 ) {
     fun toNavAction(): NavActionEntity {
@@ -33,9 +32,7 @@ data class ActionStatusEntity(
             startDateTimeUtc = startDateTimeUtc,
             status = status,
             reason = reason,
-            isStart = isStart,
             observations = observations,
-
-            )
+        )
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/GetStatusForAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/GetStatusForAction.kt
@@ -22,23 +22,8 @@ class GetStatusForAction(
         val lastActionStatus = actions
             .filter { it.startDateTimeUtc <= actionStartDateTimeUtc }
             .maxByOrNull { it.startDateTimeUtc }
-        val lastStartedActionStatus = actions
-            .filter { it.isStart && it.startDateTimeUtc <= actionStartDateTimeUtc }
-            .maxByOrNull { it.startDateTimeUtc }
 
-
-        // case where there are 2 statuses at the same timestamp, one starting, one ending:
-        if (lastActionStatus != null && lastStartedActionStatus != null && lastStartedActionStatus.startDateTimeUtc == lastActionStatus.startDateTimeUtc) {
-            return lastStartedActionStatus.status
-        }
-        // return unknown if no action or if last action is a status of type finishing and no other starting action at that timestamp
-        else if (lastActionStatus == null || (!lastActionStatus.isStart && lastStartedActionStatus?.startDateTimeUtc != lastActionStatus.startDateTimeUtc)) {
-            return ActionStatusType.UNKNOWN
-        }
-        // return status of last status, it implies it is a starting status
-        else {
-            return lastActionStatus.status
-        }
+        return lastActionStatus?.status ?: ActionStatusType.UNKNOWN
     }
 
 }

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/bff/adapters/action/ActionStatusInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/bff/adapters/action/ActionStatusInput.kt
@@ -14,7 +14,6 @@ data class ActionStatusInput(
     val startDateTimeUtc: String?,
     val status: ActionStatusType,
     val reason: ActionStatusReason?,
-    val isStart: Boolean,
     val observations: String?
 ) {
     fun toActionStatus(): ActionStatusEntity {
@@ -26,7 +25,6 @@ data class ActionStatusInput(
             } ?: ZonedDateTime.now(ZoneId.of("UTC")),
             status = status,
             reason = reason,
-            isStart = isStart,
             observations = observations
         )
     }

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/bff/model/action/Action.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/bff/model/action/Action.kt
@@ -154,8 +154,6 @@ data class Action(
         fun sortForTimeline(allActions: List<Action>?): List<Action>? {
             return allActions?.sortedWith(compareByDescending<Action> { it.startDateTimeUtc }
                 .thenBy { it.data is NavActionStatus }
-                .thenBy { (it.data as? NavActionStatus)?.isStart == false }
-                .thenBy { (it.data as? NavActionStatus)?.isStart == true }
             )
         }
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/bff/model/action/ActionData.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/bff/model/action/ActionData.kt
@@ -105,7 +105,6 @@ data class NavActionStatus(
     val startDateTimeUtc: ZonedDateTime,
     val status: ActionStatusType,
     val reason: ActionStatusReason? = null,
-    val isStart: Boolean,
     val observations: String? = null
 ) : ActionData()
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/model/mission/action/ActionStatusModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/model/mission/action/ActionStatusModel.kt
@@ -30,9 +30,6 @@ class ActionStatusModel(
     @Column(name = "reason", nullable = true)
     var reason: String?,
 
-    @Column(name = "is_start", nullable = false)
-    var isStart: Boolean,
-
     @Column(name = "observations", nullable = true)
     var observations: String?,
 
@@ -44,7 +41,6 @@ class ActionStatusModel(
             startDateTimeUtc = startDateTimeUtc,
             status = mapStringToActionStatusType(status),
             reason = mapStringToActionStatusReason(reason),
-            isStart = isStart,
             observations = observations,
         )
     }
@@ -56,7 +52,6 @@ class ActionStatusModel(
             startDateTimeUtc = statusAction.startDateTimeUtc,
             status = statusAction.status.toString(),
             reason = statusAction.reason.toStringOrNull(),
-            isStart = statusAction.isStart,
             observations = statusAction.observations,
         )
     }

--- a/backend/src/main/resources/db/migration/V1.2024.01.30.11.54__status_drop_isstart.sql
+++ b/backend/src/main/resources/db/migration/V1.2024.01.30.11.54__status_drop_isstart.sql
@@ -1,0 +1,10 @@
+DO
+$$
+  BEGIN
+
+    -- Remove the isStart column from the mission_action_status table
+    ALTER TABLE mission_action_status
+      DROP COLUMN is_start;
+
+  END
+$$;

--- a/backend/src/main/resources/graphql/action.graphqls
+++ b/backend/src/main/resources/graphql/action.graphqls
@@ -25,7 +25,6 @@ input ActionStatusInput {
   startDateTimeUtc: String
   status: ActionStatusType!
   reason: ActionStatusReason
-  isStart: Boolean!
   observations: String
 }
 
@@ -63,7 +62,6 @@ type NavActionStatus {
   startDateTimeUtc: String!
   status: ActionStatusType!
   reason: ActionStatusReason
-  isStart: Boolean!
   observations: String
 }
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/status/GetStatusForActionTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/status/GetStatusForActionTests.kt
@@ -43,36 +43,10 @@ class GetStatusForActionTests {
     @Autowired
     private lateinit var getStatusForAction: GetStatusForAction
 
-    //    @Test
-//    fun `execute Should return Unknown when action is null for a mission`() {
-//        given(this.statusActionsRepository.findAllByMissionId(missionId)).willReturn(null);
-//        val statusForAction = getStatusForAction.execute(missionId=missionId, actionStartDateTimeUtc=null);
-//        assertThat(statusForAction).isEqualTo(ActionStatusType.UNKNOWN);
-//    }
     @Test
     fun `execute Should return Unknown when action is empty list for a mission`() {
         given(this.statusActionsRepository.findAllByMissionId(missionId = 1)).willReturn(listOf<ActionStatusModel>());
         val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = null);
-        assertThat(statusForAction).isEqualTo(ActionStatusType.UNKNOWN);
-    }
-
-    @Test
-    fun `execute Should return Unknown if only finishing actions`() {
-        val startDatetime = ZonedDateTime.of(2023, 6, 19, 10, 0, 0, 0, ZoneId.of("Europe/Berlin"))
-        val finishingAction = ActionStatusEntity(
-            id = UUID.randomUUID(),
-            missionId = missionId,
-            startDateTimeUtc = startDatetime,
-            isStart = false,
-            status = ActionStatusType.UNAVAILABLE,
-        )
-        val actions = listOf(finishingAction)
-        given(this.statusActionsRepository.findAllByMissionId(missionId = 1)).willReturn(actions.map {
-            ActionStatusModel.fromActionStatusEntity(
-                it
-            )
-        });
-        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = startDatetime);
         assertThat(statusForAction).isEqualTo(ActionStatusType.UNKNOWN);
     }
 
@@ -83,7 +57,6 @@ class GetStatusForActionTests {
             id = UUID.randomUUID(),
             missionId = missionId,
             startDateTimeUtc = startDatetime,
-            isStart = true,
             status = ActionStatusType.UNAVAILABLE,
         )
         val actions = listOf(startingAction)
@@ -94,32 +67,5 @@ class GetStatusForActionTests {
         });
         val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = startDatetime);
         assertThat(statusForAction).isEqualTo(ActionStatusType.UNAVAILABLE);
-    }
-
-    @Test
-    fun `execute Should return the last started action status if last action is ending but at the same timestamp as a starting status action`() {
-        val startDatetime = ZonedDateTime.of(2023, 6, 19, 10, 0, 0, 0, ZoneId.of("Europe/Berlin"))
-        val startingAction = ActionStatusEntity(
-            id = UUID.randomUUID(),
-            missionId = missionId,
-            startDateTimeUtc = startDatetime,
-            isStart = true,
-            status = ActionStatusType.UNAVAILABLE,
-        )
-        val finishingAction = ActionStatusEntity(
-            id = UUID.randomUUID(),
-            missionId = missionId,
-            startDateTimeUtc = startDatetime,
-            isStart = false,
-            status = ActionStatusType.DOCKED,
-        )
-        val actions = listOf(finishingAction, startingAction)
-        given(this.statusActionsRepository.findAllByMissionId(missionId = 1)).willReturn(actions.map {
-            ActionStatusModel.fromActionStatusEntity(
-                it
-            )
-        });
-        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = startDatetime);
-        assertThat(statusForAction).isEqualTo(startingAction.status);
     }
 }

--- a/frontend/src/pam/mission/actions/action-status-form.tsx
+++ b/frontend/src/pam/mission/actions/action-status-form.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useState } from 'react'
 import {
-    Accent,
-    Button,
-    DatePicker,
-    Icon,
-    MultiRadio,
-    OptionValueType,
-    Size,
-    Tag,
-    Textarea,
-    THEME
+  Accent,
+  Button,
+  DatePicker,
+  Icon,
+  MultiRadio,
+  OptionValueType,
+  Size,
+  Tag,
+  Textarea,
+  THEME
 } from '@mtes-mct/monitor-ui'
 import { Action, ActionStatus, ActionStatusType, } from '../../../types/action-types'
 import { Stack } from 'rsuite'
@@ -24,171 +24,147 @@ import useAddOrUpdateStatus from "../status/use-add-update-status.tsx";
 import useDeleteStatus from "../status/use-delete-status.tsx";
 
 interface ActionStatusFormProps {
-    action: Action
+  action: Action
 }
 
 const ActionStatusForm: React.FC<ActionStatusFormProps> = ({action}) => {
-    const navigate = useNavigate()
-    const {missionId, actionId} = useParams()
+  const navigate = useNavigate()
+  const {missionId, actionId} = useParams()
 
-    const {data: navAction, loading, error} = useActionById(actionId, missionId, action.source, action.type)
-    const [mutateStatus] = useAddOrUpdateStatus()
-    const [deleteStatus] = useDeleteStatus()
+  const {data: navAction, loading, error} = useActionById(actionId, missionId, action.source, action.type)
+  const [mutateStatus] = useAddOrUpdateStatus()
+  const [deleteStatus] = useDeleteStatus()
 
-    const [observationsValue, setObservationsValue] = useState<string | undefined>(undefined)
+  const [observationsValue, setObservationsValue] = useState<string | undefined>(undefined)
 
-    useEffect(() => {
-        setObservationsValue(navAction?.data?.observations)
-    }, [navAction])
+  useEffect(() => {
+    setObservationsValue(navAction?.data?.observations)
+  }, [navAction])
 
-    if (loading) {
-        return (
-            <div>Chargement...</div>
-        )
+  if (loading) {
+    return (
+      <div>Chargement...</div>
+    )
+  }
+  if (error) {
+    return (
+      <div>error</div>
+    )
+  }
+  if (navAction) {
+    const status = navAction?.data as ActionStatus
+
+
+    const handleObservationsChange = (nextValue?: string) => {
+      setObservationsValue(nextValue)
     }
-    if (error) {
-        return (
-            <div>error</div>
-        )
+
+
+    const handleObservationsBlur = async () => {
+      await onChange('observations', observationsValue)
     }
-    if (navAction) {
-        const status = navAction?.data as ActionStatus
 
+    const onChange = async (field: string, value: any) => {
+      const updatedData = {
+        missionId: missionId,
+        ...omit(status, '__typename'),
+        [field]: value
+      }
+      await mutateStatus({variables: {statusAction: updatedData}})
+    }
 
-        const handleObservationsChange = (nextValue?: string) => {
-            setObservationsValue(nextValue)
+    const deleteAction = async () => {
+      await deleteStatus({
+        variables: {
+          id: action.id!
         }
+      })
+      navigate(`/pam/missions/${missionId}`)
+    }
 
-
-        const handleObservationsBlur = async () => {
-            await onChange('observations', observationsValue)
-        }
-
-        const onChange = async (field: string, value: any) => {
-            const updatedData = {
-                missionId: missionId,
-                ...omit(status, '__typename'),
-                [field]: value
-            }
-            await mutateStatus({variables: {statusAction: updatedData}})
-        }
-
-        const deleteAction = async () => {
-            await deleteStatus({
-                variables: {
-                    id: action.id!
-                }
-            })
-            navigate(`/pam/missions/${missionId}`)
-        }
-
-        return (
-            <form style={{width: '100%'}} data-testid={"action-status-form"}>
-                <Stack direction="column" spacing="2rem" alignItems="flex-start" style={{width: '100%'}}>
-                    {/* TITLE AND BUTTONS */}
-                    <Stack.Item style={{width: '100%'}}>
-                        <Stack direction="row" spacing="0.5rem" style={{width: '100%'}}>
-                            <Stack.Item alignSelf="baseline">
-                                <Icon.FleetSegment color={THEME.color.charcoal} size={20}/>
-                            </Stack.Item>
-                            <Stack.Item grow={2}>
-                                <Stack direction="column" alignItems="flex-start">
-                                    <Stack.Item>
-                                        <Text as="h2" weight="bold">
-                                            Statut du navire{' '}
-                                            {status.startDateTimeUtc && `(${formatDateTimeForFrenchHumans(status.startDateTimeUtc)})`}
-                                        </Text>
-                                    </Stack.Item>
-                                </Stack>
-                            </Stack.Item>
-                            <Stack.Item>
-                                <Stack direction="row" spacing="0.5rem">
-                                    <Stack.Item>
-                                        <Button accent={Accent.SECONDARY} size={Size.SMALL} Icon={Icon.Duplicate}
-                                                disabled>
-                                            Dupliquer
-                                        </Button>
-                                    </Stack.Item>
-                                    <Stack.Item>
-                                        <Button accent={Accent.SECONDARY} size={Size.SMALL} Icon={Icon.Delete}
-                                                onClick={deleteAction} data-testid={"deleteButton"}>
-                                            Supprimer
-                                        </Button>
-                                    </Stack.Item>
-                                </Stack>
-                            </Stack.Item>
-                        </Stack>
-                    </Stack.Item>
-                    {/* STATUS FIELDS */}
-                    <Stack.Item style={{width: '100%'}}>
-                        <Stack direction="row" spacing="2rem" style={{width: '100%'}}>
-                            <Stack.Item>
-                                <Tag bullet="DISK" bulletColor={getColorForStatus(ActionStatusType[action.status])}
-                                     isLight>
-                                    {mapStatusToText(ActionStatusType[action.status])}
-                                </Tag>
-                            </Stack.Item>
-                            <Stack.Item>
-                                <MultiRadio
-                                    value={status.isStart || false}
-                                    error=""
-                                    isInline
-                                    label=""
-                                    name="isStart"
-                                    onChange={(nextValue: OptionValueType) => onChange('isStart', nextValue)}
-                                    options={[
-                                        {
-                                            label: 'Début',
-                                            value: true
-                                        },
-                                        {
-                                            label: 'Fin',
-                                            value: false
-                                        }
-                                    ]}
-                                />
-                            </Stack.Item>
-                        </Stack>
-                    </Stack.Item>
-                    {/* DATE & REASON FIELDS */}
-                    <Stack.Item style={{width: '100%'}}>
-                        <Stack direction="row" spacing="0.5rem" style={{width: '100%'}}>
-                            <Stack.Item grow={1}>
-                                <DatePicker
-                                    defaultValue={status.startDateTimeUtc}
-                                    label="Date et heure"
-                                    withTime={true}
-                                    isCompact={false}
-                                    isLight={true}
-                                    name="startDateTimeUtc"
-                                    onChange={async (nextUtcDate: Date) => {
-                                        const date = new Date(nextUtcDate)
-                                        await onChange('startDateTimeUtc', date.toISOString())
-                                    }}
-                                />
-                            </Stack.Item>
-                            <Stack.Item grow={3}>
-                                <StatusReasonDropdown actionType={status.status} value={status.reason}
-                                                      onSelect={onChange}/>
-                            </Stack.Item>
-                        </Stack>
-                    </Stack.Item>
-                    <Stack.Item style={{width: '100%'}}>
-                        <Textarea
-                            label="Observations"
-                            value={observationsValue}
-                            isLight={true}
-                            name="observations"
-                            data-testid="observations"
-                            onChange={handleObservationsChange}
-                            onBlur={handleObservationsBlur}
-                        />
-                    </Stack.Item>
+    return (
+      <form style={{width: '100%'}} data-testid={"action-status-form"}>
+        <Stack direction="column" spacing="2rem" alignItems="flex-start" style={{width: '100%'}}>
+          {/* TITLE AND BUTTONS */}
+          <Stack.Item style={{width: '100%'}}>
+            <Stack direction="row" spacing="0.5rem" style={{width: '100%'}}>
+              <Stack.Item alignSelf="baseline">
+                <Icon.FleetSegment color={THEME.color.charcoal} size={20}/>
+              </Stack.Item>
+              <Stack.Item grow={2}>
+                <Stack direction="column" alignItems="flex-start">
+                  <Stack.Item>
+                    <Text as="h2" weight="bold">
+                      Statut du navire{' '}
+                      {status.startDateTimeUtc && `(${formatDateTimeForFrenchHumans(status.startDateTimeUtc)})`}
+                    </Text>
+                  </Stack.Item>
                 </Stack>
-            </form>
-        )
-    }
-    return null
+              </Stack.Item>
+              <Stack.Item>
+                <Stack direction="row" spacing="0.5rem">
+                  <Stack.Item>
+                    <Button accent={Accent.SECONDARY} size={Size.SMALL} Icon={Icon.Duplicate}
+                            disabled>
+                      Dupliquer
+                    </Button>
+                  </Stack.Item>
+                  <Stack.Item>
+                    <Button accent={Accent.SECONDARY} size={Size.SMALL} Icon={Icon.Delete}
+                            onClick={deleteAction} data-testid={"deleteButton"}>
+                      Supprimer
+                    </Button>
+                  </Stack.Item>
+                </Stack>
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+          {/* STATUS FIELDS */}
+          <Stack.Item style={{width: '100%'}}>
+            <Tag bullet="DISK" bulletColor={getColorForStatus(ActionStatusType[action.status])}
+                 isLight>
+              {mapStatusToText(ActionStatusType[action.status])}
+            </Tag>
+          </Stack.Item>
+          {/* DATE & REASON FIELDS */}
+          <Stack.Item style={{width: '100%'}}>
+            <Stack direction="row" spacing="0.5rem" style={{width: '100%'}}>
+              <Stack.Item grow={1}>
+                <DatePicker
+                  defaultValue={status.startDateTimeUtc}
+                  label="Date et heure"
+                  withTime={true}
+                  isCompact={false}
+                  isLight={true}
+                  name="startDateTimeUtc"
+                  onChange={async (nextUtcDate: Date) => {
+                    const date = new Date(nextUtcDate)
+                    await onChange('startDateTimeUtc', date.toISOString())
+                  }}
+                />
+              </Stack.Item>
+              <Stack.Item grow={3}>
+                <StatusReasonDropdown actionType={status.status} value={status.reason}
+                                      onSelect={onChange}/>
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+          <Stack.Item style={{width: '100%'}}>
+            <Textarea
+              label="Observations"
+              value={observationsValue}
+              isLight={true}
+              name="observations"
+              data-testid="observations"
+              onChange={handleObservationsChange}
+              onBlur={handleObservationsBlur}
+            />
+          </Stack.Item>
+        </Stack>
+      </form>
+    )
+  }
+  return null
 }
 
 export default ActionStatusForm

--- a/frontend/src/pam/mission/actions/use-action-by-id.tsx
+++ b/frontend/src/pam/mission/actions/use-action-by-id.tsx
@@ -201,7 +201,6 @@ export const GET_ACTION_BY_ID = gql`
           startDateTimeUtc
           status
           reason
-          isStart
           observations
         }
         ... on NavActionControl {

--- a/frontend/src/pam/mission/mission-content.tsx
+++ b/frontend/src/pam/mission/mission-content.tsx
@@ -18,190 +18,189 @@ import useAddOrUpdateControl from "./controls/use-add-update-control.tsx";
 import useAddOrUpdateStatus from "./status/use-add-update-status.tsx";
 
 export interface MissionProps {
-    mission?: Mission
+  mission?: Mission
 }
 
 const MissionContent: React.FC<MissionProps> = ({mission}) => {
-    const {missionId, actionId} = useParams()
+  const {missionId, actionId} = useParams()
 
-    let navigate = useNavigate()
+  let navigate = useNavigate()
 
-    const [showControlTypesModal, setShowControlTypesModal] = useState<boolean>(false)
+  const [showControlTypesModal, setShowControlTypesModal] = useState<boolean>(false)
 
 
-    const [addStatus, {loading: addStatusLoading}] = useAddOrUpdateStatus()
-    const [addControl] = useAddOrUpdateControl()
+  const [addStatus, {loading: addStatusLoading}] = useAddOrUpdateStatus()
+  const [addControl] = useAddOrUpdateControl()
 
-    const selectedAction = useMemo(() => {
-        if (actionId) {
-            return find(mission?.actions, {id: actionId})
-        }
-    }, [mission, actionId])
+  const selectedAction = useMemo(() => {
+    if (actionId) {
+      return find(mission?.actions, {id: actionId})
+    }
+  }, [mission, actionId])
 
-    const selectAction = (action: Action) => {
-        navigate(`/pam/missions/${missionId}/${action.id}`)
-        // setSelectedAction(action)
+  const selectAction = (action: Action) => {
+    navigate(`/pam/missions/${missionId}/${action.id}`)
+    // setSelectedAction(action)
+  }
+
+  const addNewAction = (key: ActionTypeEnum) => {
+    if (key === ActionTypeEnum.CONTROL) {
+      setShowControlTypesModal(true)
+    }
+  }
+
+  const addNewStatus = async (key: ActionStatusType) => {
+    const newActionData = {
+      missionId: parseInt(missionId!, 10),
+      startDateTimeUtc: formatDateForServers(toLocalISOString()),
+      status: key,
+      reason: null,
+      observations: null
     }
 
-    const addNewAction = (key: ActionTypeEnum) => {
-        if (key === ActionTypeEnum.CONTROL) {
-            setShowControlTypesModal(true)
-        }
+    const response = await addStatus({
+      variables: {
+        statusAction: newActionData
+      }
+    })
+
+    // TODO change this
+    navigate(`/pam/missions/${missionId}/${response.data.addOrUpdateStatus.id}`)
+  }
+
+  const addNewControl = async (controlMethod: string, vesselType: VesselTypeEnum) => {
+    setShowControlTypesModal(false)
+
+    const newControl = {
+      missionId: parseInt(missionId!, 10),
+      startDateTimeUtc: formatDateForServers(toLocalISOString()),
+      endDateTimeUtc: formatDateForServers(toLocalISOString()),
+      controlMethod,
+      vesselType
     }
 
-    const addNewStatus = async (key: ActionStatusType) => {
-        const newActionData = {
-            missionId: parseInt(missionId!, 10),
-            startDateTimeUtc: formatDateForServers(toLocalISOString()),
-            status: key,
-            isStart: true,
-            reason: null,
-            observations: null
-        }
-
-        const response = await addStatus({
-            variables: {
-                statusAction: newActionData
-            }
-        })
-
-        // TODO change this
-        navigate(`/pam/missions/${missionId}/${response.data.addOrUpdateStatus.id}`)
-    }
-
-    const addNewControl = async (controlMethod: string, vesselType: VesselTypeEnum) => {
-        setShowControlTypesModal(false)
-
-        const newControl = {
-            missionId: parseInt(missionId!, 10),
-            startDateTimeUtc: formatDateForServers(toLocalISOString()),
-            endDateTimeUtc: formatDateForServers(toLocalISOString()),
-            controlMethod,
-            vesselType
-        }
-
-        const response = await addControl({variables: {controlAction: newControl}})
-        navigate(`/pam/missions/${missionId}/${response.data.addOrUpdateControl.id}`)
-    }
+    const response = await addControl({variables: {controlAction: newControl}})
+    navigate(`/pam/missions/${missionId}/${response.data.addOrUpdateControl.id}`)
+  }
 
 
-    if (mission) {
-        const MissionActionComponent = getComponentForAction(selectedAction)
+  if (mission) {
+    const MissionActionComponent = getComponentForAction(selectedAction)
 
-        return (
-            <>
-                <FlexboxGrid justify="space-between" style={{display: 'flex', flex: 1}}>
-                    <FlexboxGrid.Item
-                        colspan={8}
-                        style={{
-                            flex: 1,
-                            overflowY: 'auto',
-                            minHeight: 'calc(100vh - 2 * 60px)',
-                            maxHeight: 'calc(100vh - 2 * 60px)'
-                        }}
-                    >
-                        <Stack direction="column">
-                            <Stack.Item style={{width: '100%', padding: '1rem'}}>
-                                <MissionGeneralInfoPanel mission={mission}/>
-                            </Stack.Item>
-                            <Stack.Item
-                                style={{width: '100%', padding: '1rem'}}>{/* <MissionActivityPanel /> */}</Stack.Item>
-                            <Stack.Item style={{width: '100%', padding: '1rem'}}>
-                                {/* <MissionOperationalSummaryPanel /> */}
-                            </Stack.Item>
-                        </Stack>
-                    </FlexboxGrid.Item>
-                    <FlexboxGrid.Item
-                        colspan={8}
-                        style={{
-                            backgroundColor: THEME.color.cultured,
-                            padding: '2rem',
-                            flex: 1,
-                            overflowY: 'hidden',
-                            minHeight: 'calc(100vh - 2 * 60px)',
-                            maxHeight: 'calc(100vh - 2 * 60px)',
-                            height: '2000px', // for having 100% height children
-                        }}
-                    >
-                        <FlexboxGrid>
-                            <FlexboxGrid.Item style={{width: '100%'}}>
-                                <FlexboxGrid justify="space-between">
-                                    <FlexboxGrid.Item>
-                                        <Stack alignItems="center">
-                                            <Stack.Item>
-                                                <Text as="h2" weight="bold">
-                                                    Actions réalisées en mission
-                                                </Text>
-                                            </Stack.Item>
-                                            <Stack.Item style={{paddingLeft: '0.5rem'}}>
-                                                <ActionSelectionDropdown onSelect={addNewAction}/>
-                                            </Stack.Item>
-                                        </Stack>
-                                    </FlexboxGrid.Item>
-                                    <FlexboxGrid.Item>
-                                        <Stack>
-                                            {/* <Stack.Item>
+    return (
+      <>
+        <FlexboxGrid justify="space-between" style={{display: 'flex', flex: 1}}>
+          <FlexboxGrid.Item
+            colspan={8}
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              minHeight: 'calc(100vh - 2 * 60px)',
+              maxHeight: 'calc(100vh - 2 * 60px)'
+            }}
+          >
+            <Stack direction="column">
+              <Stack.Item style={{width: '100%', padding: '1rem'}}>
+                <MissionGeneralInfoPanel mission={mission}/>
+              </Stack.Item>
+              <Stack.Item
+                style={{width: '100%', padding: '1rem'}}>{/* <MissionActivityPanel /> */}</Stack.Item>
+              <Stack.Item style={{width: '100%', padding: '1rem'}}>
+                {/* <MissionOperationalSummaryPanel /> */}
+              </Stack.Item>
+            </Stack>
+          </FlexboxGrid.Item>
+          <FlexboxGrid.Item
+            colspan={8}
+            style={{
+              backgroundColor: THEME.color.cultured,
+              padding: '2rem',
+              flex: 1,
+              overflowY: 'hidden',
+              minHeight: 'calc(100vh - 2 * 60px)',
+              maxHeight: 'calc(100vh - 2 * 60px)',
+              height: '2000px', // for having 100% height children
+            }}
+          >
+            <FlexboxGrid>
+              <FlexboxGrid.Item style={{width: '100%'}}>
+                <FlexboxGrid justify="space-between">
+                  <FlexboxGrid.Item>
+                    <Stack alignItems="center">
+                      <Stack.Item>
+                        <Text as="h2" weight="bold">
+                          Actions réalisées en mission
+                        </Text>
+                      </Stack.Item>
+                      <Stack.Item style={{paddingLeft: '0.5rem'}}>
+                        <ActionSelectionDropdown onSelect={addNewAction}/>
+                      </Stack.Item>
+                    </Stack>
+                  </FlexboxGrid.Item>
+                  <FlexboxGrid.Item>
+                    <Stack>
+                      {/* <Stack.Item>
                         <IconButton
                           Icon={Icon.Phone}
                           accent={Accent.PRIMARY}
                           size={Size.NORMAL}
                         />
                       </Stack.Item> */}
-                                            <Stack.Item style={{paddingLeft: '0.5rem'}}>
-                                                <StatusSelectionDropdown onSelect={addNewStatus}
-                                                                         loading={addStatusLoading}/>
-                                            </Stack.Item>
-                                        </Stack>
-                                    </FlexboxGrid.Item>
-                                </FlexboxGrid>
-                                <Divider style={{backgroundColor: THEME.color.charcoal}}/>
-                            </FlexboxGrid.Item>
-                            <FlexboxGrid.Item style={{
-                                width: '100%',
-                                overflowY: 'auto',
-                                minHeight: 'calc(100vh - 260px)',
-                                maxHeight: 'calc(100vh - 260px)',
-                                height: '2000px', // for having 100% height children
-                            }}>
-                                <MissionTimeline missionId={missionId} onSelectAction={selectAction}/>
-                            </FlexboxGrid.Item>
-                        </FlexboxGrid>
-                    </FlexboxGrid.Item>
-                    <FlexboxGrid.Item
-                        colspan={8}
-                        style={{
-                            backgroundColor: THEME.color.gainsboro,
-                            flex: 1,
-                            overflowY: 'auto',
-                            minHeight: 'calc(100vh - 2 * 60px)',
-                            maxHeight: 'calc(100vh - 2 * 60px)',
-                            height: '2000px', // for having 100% height children
-                        }}
-                    >
-                        <FlexboxGrid justify="start" align="middle" style={{padding: '2rem', width: '100%'}}>
-                            {selectedAction && MissionActionComponent &&
-                                <MissionActionComponent action={selectedAction}/>}
-                        </FlexboxGrid>
-                    </FlexboxGrid.Item>
+                      <Stack.Item style={{paddingLeft: '0.5rem'}}>
+                        <StatusSelectionDropdown onSelect={addNewStatus}
+                                                 loading={addStatusLoading}/>
+                      </Stack.Item>
+                    </Stack>
+                  </FlexboxGrid.Item>
                 </FlexboxGrid>
-                <>
-                    {showControlTypesModal && (
-                        <Dialog>
-                            <Dialog.Title>Ajouter des contrôles</Dialog.Title>
-                            <Dialog.Body>
-                                <ControlSelection onSelect={addNewControl}/>
-                            </Dialog.Body>
-                            <Dialog.Action style={{justifyContent: 'flex-end', paddingRight: '1.5rem'}}>
-                                <Button accent={Accent.SECONDARY} onClick={() => setShowControlTypesModal(false)}>
-                                    Fermer
-                                </Button>
-                            </Dialog.Action>
-                        </Dialog>
-                    )}
-                </>
-            </>
-        )
-    }
+                <Divider style={{backgroundColor: THEME.color.charcoal}}/>
+              </FlexboxGrid.Item>
+              <FlexboxGrid.Item style={{
+                width: '100%',
+                overflowY: 'auto',
+                minHeight: 'calc(100vh - 260px)',
+                maxHeight: 'calc(100vh - 260px)',
+                height: '2000px', // for having 100% height children
+              }}>
+                <MissionTimeline missionId={missionId} onSelectAction={selectAction}/>
+              </FlexboxGrid.Item>
+            </FlexboxGrid>
+          </FlexboxGrid.Item>
+          <FlexboxGrid.Item
+            colspan={8}
+            style={{
+              backgroundColor: THEME.color.gainsboro,
+              flex: 1,
+              overflowY: 'auto',
+              minHeight: 'calc(100vh - 2 * 60px)',
+              maxHeight: 'calc(100vh - 2 * 60px)',
+              height: '2000px', // for having 100% height children
+            }}
+          >
+            <FlexboxGrid justify="start" align="middle" style={{padding: '2rem', width: '100%'}}>
+              {selectedAction && MissionActionComponent &&
+                <MissionActionComponent action={selectedAction}/>}
+            </FlexboxGrid>
+          </FlexboxGrid.Item>
+        </FlexboxGrid>
+        <>
+          {showControlTypesModal && (
+            <Dialog>
+              <Dialog.Title>Ajouter des contrôles</Dialog.Title>
+              <Dialog.Body>
+                <ControlSelection onSelect={addNewControl}/>
+              </Dialog.Body>
+              <Dialog.Action style={{justifyContent: 'flex-end', paddingRight: '1.5rem'}}>
+                <Button accent={Accent.SECONDARY} onClick={() => setShowControlTypesModal(false)}>
+                  Fermer
+                </Button>
+              </Dialog.Action>
+            </Dialog>
+          )}
+        </>
+      </>
+    )
+  }
 }
 
 export default MissionContent

--- a/frontend/src/pam/mission/queries.ts
+++ b/frontend/src/pam/mission/queries.ts
@@ -1,349 +1,348 @@
 import { gql } from '@apollo/client'
 
 export const GET_MISSION_BY_ID = gql`
-    query GetMissionById($missionId: ID) {
-        mission(missionId: $missionId) {
+  query GetMissionById($missionId: ID) {
+    mission(missionId: $missionId) {
+      id
+      missionSource
+      startDateTimeUtc
+      endDateTimeUtc
+      generalInfo {
+        id
+        distanceInNauticalMiles
+        consumedGOInLiters
+        consumedFuelInLiters
+      }
+      actions {
+        id
+        type
+        source
+        status
+        startDateTimeUtc
+        endDateTimeUtc
+        data {
+          ... on FishActionData {
             id
-            missionSource
-            startDateTimeUtc
-            endDateTimeUtc
-            generalInfo {
-                id
-                distanceInNauticalMiles
-                consumedGOInLiters
-                consumedFuelInLiters
+            actionType
+            actionDatetimeUtc
+            vesselId
+            vesselName
+            latitude
+            longitude
+            facade
+            emitsVms
+            emitsAis
+            licencesMatchActivity
+            logbookMatchesActivity
+            licencesAndLogbookObservations
+            gearOnboard {
+              comments
+              controlledMesh
+              declaredMesh
+              gearCode
+              gearName
+              gearWasControlled
+              hasUncontrolledMesh
             }
-            actions {
+            speciesObservations
+            speciesOnboard {
+              speciesCode
+              nbFish
+              declaredWeight
+              controlledWeight
+              underSized
+            }
+            seizureAndDiversion
+            seizureAndDiversionComments
+            hasSomeGearsSeized
+            hasSomeSpeciesSeized
+            otherComments
+            faoAreas
+            segments {
+              segment
+              segmentName
+            }
+            vesselTargeted
+            unitWithoutOmegaGauge
+            controlQualityComments
+            feedbackSheetRequired
+            userTrigram
+            controlsToComplete
+            controlAdministrative {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              compliantOperatingPermit
+              upToDateNavigationPermit
+              compliantSecurityDocuments
+              observations
+              infractions {
                 id
-                type
-                source
-                status
-                startDateTimeUtc
-                endDateTimeUtc
-                data {
-                    ... on FishActionData {
-                        id
-                        actionType
-                        actionDatetimeUtc
-                        vesselId
-                        vesselName
-                        latitude
-                        longitude
-                        facade
-                        emitsVms
-                        emitsAis
-                        licencesMatchActivity
-                        logbookMatchesActivity
-                        licencesAndLogbookObservations
-                        gearOnboard {
-                            comments
-                            controlledMesh
-                            declaredMesh
-                            gearCode
-                            gearName
-                            gearWasControlled
-                            hasUncontrolledMesh
-                        }
-                        speciesObservations
-                        speciesOnboard {
-                            speciesCode
-                            nbFish
-                            declaredWeight
-                            controlledWeight
-                            underSized
-                        }
-                        seizureAndDiversion
-                        seizureAndDiversionComments
-                        hasSomeGearsSeized
-                        hasSomeSpeciesSeized
-                        otherComments
-                        faoAreas
-                        segments {
-                            segment
-                            segmentName
-                        }
-                        vesselTargeted
-                        unitWithoutOmegaGauge
-                        controlQualityComments
-                        feedbackSheetRequired
-                        userTrigram
-                        controlsToComplete
-                        controlAdministrative {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            compliantOperatingPermit
-                            upToDateNavigationPermit
-                            compliantSecurityDocuments
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                        controlGensDeMer {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            staffOutnumbered
-                            upToDateMedicalCheck
-                            knowledgeOfFrenchLawAndLanguage
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                        controlNavigation {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                        controlSecurity {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                    }
-                    ... on EnvActionData {
-                        id
-                        observations
-                        actionNumberOfControls
-                        actionTargetType
-                        vehicleType
-                        controlsToComplete
-                        availableControlTypesForInfraction
-                        themes {
-                            theme
-                            subThemes
-                        }
-                        infractions {
-                            vesselIdentifier
-                            vesselType
-                            targetAddedByUnit
-                            controlTypesWithInfraction
-                            infractions {
-                                id
-                                controlType
-                                observations
-                                infractionType
-                                natinfs
-                                target {
-                                    formalNotice
-                                    companyName
-                                    relevantCourt
-                                    infractionType
-                                    toProcess
-                                    vesselType
-                                    vesselSize
-                                    vesselIdentifier
-                                    identityControlledPerson
-                                }
-                            }
-                        }
-                        controlAdministrative {
-                            id
-                            amountOfControls
-                            observations
-                        }
-                        controlSecurity {
-                            id
-                            amountOfControls
-                            observations
-                        }
-                        controlNavigation {
-                            id
-                            amountOfControls
-                            observations
-                        }
-                        controlGensDeMer {
-                            id
-                            amountOfControls
-                            observations
-                        }
-                    }
-                    ... on NavActionStatus {
-                        id
-                        startDateTimeUtc
-                        status
-                        reason
-                        isStart
-                        observations
-                    }
-                    ... on NavActionControl {
-                        id
-                        latitude
-                        longitude
-                        controlMethod
-                        vesselIdentifier
-                        vesselType
-                        vesselSize
-                        observations
-                        identityControlledPerson
-                        controlAdministrative {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            compliantOperatingPermit
-                            upToDateNavigationPermit
-                            compliantSecurityDocuments
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                        controlGensDeMer {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            staffOutnumbered
-                            upToDateMedicalCheck
-                            knowledgeOfFrenchLawAndLanguage
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                        controlNavigation {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                        controlSecurity {
-                            id
-                            amountOfControls
-                            unitShouldConfirm
-                            unitHasConfirmed
-                            observations
-                            infractions {
-                                id
-                                natinfs
-                                infractionType
-                                observations
-                            }
-                        }
-                    }
+                natinfs
+                infractionType
+                observations
+              }
+            }
+            controlGensDeMer {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              staffOutnumbered
+              upToDateMedicalCheck
+              knowledgeOfFrenchLawAndLanguage
+              observations
+              infractions {
+                id
+                natinfs
+                infractionType
+                observations
+              }
+            }
+            controlNavigation {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              observations
+              infractions {
+                id
+                natinfs
+                infractionType
+                observations
+              }
+            }
+            controlSecurity {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              observations
+              infractions {
+                id
+                natinfs
+                infractionType
+                observations
+              }
+            }
+          }
+          ... on EnvActionData {
+            id
+            observations
+            actionNumberOfControls
+            actionTargetType
+            vehicleType
+            controlsToComplete
+            availableControlTypesForInfraction
+            themes {
+              theme
+              subThemes
+            }
+            infractions {
+              vesselIdentifier
+              vesselType
+              targetAddedByUnit
+              controlTypesWithInfraction
+              infractions {
+                id
+                controlType
+                observations
+                infractionType
+                natinfs
+                target {
+                  formalNotice
+                  companyName
+                  relevantCourt
+                  infractionType
+                  toProcess
+                  vesselType
+                  vesselSize
+                  vesselIdentifier
+                  identityControlledPerson
                 }
+              }
             }
+            controlAdministrative {
+              id
+              amountOfControls
+              observations
+            }
+            controlSecurity {
+              id
+              amountOfControls
+              observations
+            }
+            controlNavigation {
+              id
+              amountOfControls
+              observations
+            }
+            controlGensDeMer {
+              id
+              amountOfControls
+              observations
+            }
+          }
+          ... on NavActionStatus {
+            id
+            startDateTimeUtc
+            status
+            reason
+            observations
+          }
+          ... on NavActionControl {
+            id
+            latitude
+            longitude
+            controlMethod
+            vesselIdentifier
+            vesselType
+            vesselSize
+            observations
+            identityControlledPerson
+            controlAdministrative {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              compliantOperatingPermit
+              upToDateNavigationPermit
+              compliantSecurityDocuments
+              observations
+              infractions {
+                id
+                natinfs
+                infractionType
+                observations
+              }
+            }
+            controlGensDeMer {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              staffOutnumbered
+              upToDateMedicalCheck
+              knowledgeOfFrenchLawAndLanguage
+              observations
+              infractions {
+                id
+                natinfs
+                infractionType
+                observations
+              }
+            }
+            controlNavigation {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              observations
+              infractions {
+                id
+                natinfs
+                infractionType
+                observations
+              }
+            }
+            controlSecurity {
+              id
+              amountOfControls
+              unitShouldConfirm
+              unitHasConfirmed
+              observations
+              infractions {
+                id
+                natinfs
+                infractionType
+                observations
+              }
+            }
+          }
         }
+      }
     }
+  }
 `
 
 
 export const MUTATION_ADD_OR_UPDATE_CONTROL_GENS_DE_MER = gql`
-    mutation AddOrUpdateControlGensDeMer($control: ControlGensDeMerInput!) {
-        addOrUpdateControlGensDeMer(control: $control) {
-            id
-            amountOfControls
-            unitShouldConfirm
-            unitHasConfirmed
-            staffOutnumbered
-            upToDateMedicalCheck
-            knowledgeOfFrenchLawAndLanguage
-            observations
-        }
+  mutation AddOrUpdateControlGensDeMer($control: ControlGensDeMerInput!) {
+    addOrUpdateControlGensDeMer(control: $control) {
+      id
+      amountOfControls
+      unitShouldConfirm
+      unitHasConfirmed
+      staffOutnumbered
+      upToDateMedicalCheck
+      knowledgeOfFrenchLawAndLanguage
+      observations
     }
+  }
 `
 
 export const MUTATION_ADD_OR_UPDATE_CONTROL_NAVIGATION = gql`
-    mutation AddOrUpdateControlNavigation($control: ControlNavigationInput!) {
-        addOrUpdateControlNavigation(control: $control) {
-            id
-            amountOfControls
-            unitShouldConfirm
-            unitHasConfirmed
-            observations
-        }
+  mutation AddOrUpdateControlNavigation($control: ControlNavigationInput!) {
+    addOrUpdateControlNavigation(control: $control) {
+      id
+      amountOfControls
+      unitShouldConfirm
+      unitHasConfirmed
+      observations
     }
+  }
 `
 
 export const MUTATION_ADD_OR_UPDATE_CONTROL_SECURITY = gql`
-    mutation AddOrUpdateControlSecurity($control: ControlSecurityInput!) {
-        addOrUpdateControlSecurity(control: $control) {
-            id
-            amountOfControls
-            unitShouldConfirm
-            unitHasConfirmed
-            observations
-        }
+  mutation AddOrUpdateControlSecurity($control: ControlSecurityInput!) {
+    addOrUpdateControlSecurity(control: $control) {
+      id
+      amountOfControls
+      unitShouldConfirm
+      unitHasConfirmed
+      observations
     }
+  }
 `
 
 export const MUTATION_ADD_OR_UPDATE_CONTROL_ADMINISTRATIVE = gql`
-    mutation AddOrUpdateControlAdministrative($control: ControlAdministrativeInput!) {
-        addOrUpdateControlAdministrative(control: $control) {
-            id
-            amountOfControls
-            unitShouldConfirm
-            unitHasConfirmed
-            compliantOperatingPermit
-            upToDateNavigationPermit
-            compliantSecurityDocuments
-            observations
-        }
+  mutation AddOrUpdateControlAdministrative($control: ControlAdministrativeInput!) {
+    addOrUpdateControlAdministrative(control: $control) {
+      id
+      amountOfControls
+      unitShouldConfirm
+      unitHasConfirmed
+      compliantOperatingPermit
+      upToDateNavigationPermit
+      compliantSecurityDocuments
+      observations
     }
+  }
 `
 
 export const DELETE_CONTROL_ADMINISTRATIVE = gql`
-    mutation DeleteControlAdministrative($actionId: String!) {
-        deleteControlAdministrative(actionId: $actionId)
-    }
+  mutation DeleteControlAdministrative($actionId: String!) {
+    deleteControlAdministrative(actionId: $actionId)
+  }
 `
 
 export const DELETE_CONTROL_NAVIGATION = gql`
-    mutation DeleteControlNavigation($actionId: String!) {
-        deleteControlNavigation(actionId: $actionId)
-    }
+  mutation DeleteControlNavigation($actionId: String!) {
+    deleteControlNavigation(actionId: $actionId)
+  }
 `
 
 export const DELETE_CONTROL_SECURITY = gql`
-    mutation DeleteControlSecurity($actionId: String!) {
-        deleteControlSecurity(actionId: $actionId)
-    }
+  mutation DeleteControlSecurity($actionId: String!) {
+    deleteControlSecurity(actionId: $actionId)
+  }
 `
 
 export const DELETE_CONTROL_GENS_DE_MER = gql`
-    mutation DeleteControlGensDeMer($actionId: String!) {
-        deleteControlGensDeMer(actionId: $actionId)
-    }
+  mutation DeleteControlGensDeMer($actionId: String!) {
+    deleteControlGensDeMer(actionId: $actionId)
+  }
 `
 
 
@@ -355,13 +354,13 @@ export const DELETE_CONTROL_GENS_DE_MER = gql`
 
 
 export const GET_AGENTS_BY_SERVICE = gql`
-    query GetAgentsByServiceId($serviceId: ID!) {
-        agentsByServiceId(serviceId: $serviceId) {
-            id
-            firstName
-            lastName
-        }
+  query GetAgentsByServiceId($serviceId: ID!) {
+    agentsByServiceId(serviceId: $serviceId) {
+      id
+      firstName
+      lastName
     }
+  }
 `
 
 

--- a/frontend/src/pam/mission/status/use-add-update-status.tsx
+++ b/frontend/src/pam/mission/status/use-add-update-status.tsx
@@ -4,25 +4,24 @@ import { GET_ACTION_BY_ID } from "../actions/use-action-by-id.tsx";
 import { ActionStatus } from "../../../types/action-types.ts";
 
 export const MUTATION_ADD_OR_UPDATE_ACTION_STATUS = gql`
-    mutation AddOrUpdateStatus($statusAction: ActionStatusInput!) {
-        addOrUpdateStatus(statusAction: $statusAction) {
-            id
-            startDateTimeUtc
-            status
-            reason
-            isStart
-            observations
-        }
+  mutation AddOrUpdateStatus($statusAction: ActionStatusInput!) {
+    addOrUpdateStatus(statusAction: $statusAction) {
+      id
+      startDateTimeUtc
+      status
+      reason
+      observations
     }
+  }
 `
 
 
 const useAddOrUpdateStatus = (): MutationTuple<ActionStatus, Record<string, any>> => {
-    const mutation = useMutation(MUTATION_ADD_OR_UPDATE_ACTION_STATUS, {
-        refetchQueries: [GET_MISSION_TIMELINE, GET_ACTION_BY_ID]
-    })
+  const mutation = useMutation(MUTATION_ADD_OR_UPDATE_ACTION_STATUS, {
+    refetchQueries: [GET_MISSION_TIMELINE, GET_ACTION_BY_ID]
+  })
 
-    return mutation
+  return mutation
 }
 
 export default useAddOrUpdateStatus

--- a/frontend/src/pam/mission/timeline/item/timeline-item-status.test.tsx
+++ b/frontend/src/pam/mission/timeline/item/timeline-item-status.test.tsx
@@ -1,70 +1,59 @@
 import { render, screen } from '../../../../test-utils.tsx'
 import { Action } from "@sentry/react/types/types";
 import {
-    ActionTargetTypeEnum,
-    ActionTypeEnum,
-    NavAction,
-    MissionSourceEnum
+  ActionTypeEnum,
+  MissionSourceEnum
 } from "../../../../types/env-mission-types.ts";
 import {
-    ActionControl,
-    ActionStatusType,
-    ActionStatus as ActionStatusBaseType,
-    ActionStatusReason
+  ActionStatusType,
+  ActionStatus as ActionStatusBaseType,
+  ActionStatusReason
 } from "../../../../types/action-types.ts";
 import ActionStatus from "./timeline-item-status.tsx";
-import { ControlMethod } from "../../../../types/control-types.ts";
-import { VesselTypeEnum } from "../../../../types/mission-types.ts";
 
 
 const actionMock = {
-    id: '1',
-    missionId: 1,
-    type: ActionTypeEnum.CONTROL,
-    source: MissionSourceEnum.RAPPORTNAV,
-    status: ActionStatusType.DOCKED,
+  id: '1',
+  missionId: 1,
+  type: ActionTypeEnum.CONTROL,
+  source: MissionSourceEnum.RAPPORTNAV,
+  status: ActionStatusType.DOCKED,
+  startDateTimeUtc: '2022-01-01T00:00:00Z',
+  endDateTimeUtc: '2022-01-01T01:00:00Z',
+  summaryTags: undefined,
+  controlsToComplete: undefined,
+  data: {
     startDateTimeUtc: '2022-01-01T00:00:00Z',
     endDateTimeUtc: '2022-01-01T01:00:00Z',
-    summaryTags: undefined,
-    controlsToComplete: undefined,
-    data: {
-        startDateTimeUtc: '2022-01-01T00:00:00Z',
-        endDateTimeUtc: '2022-01-01T01:00:00Z',
-        status: ActionStatusType.UNAVAILABLE,
-        isStart: true,
-        reason: ActionStatusReason.TECHNICAL,
-        observations: 'obs'
-    } as any as ActionStatusBaseType
+    status: ActionStatusType.UNAVAILABLE,
+    reason: ActionStatusReason.TECHNICAL,
+    observations: 'obs'
+  } as any as ActionStatusBaseType
 }
 
 const props = (action: Action = actionMock, onClick = vi.fn()) => ({
-    action,
-    onClick
+  action,
+  onClick
 })
 describe('ActionStatus', () => {
-    test('should render', () => {
-        render(<ActionStatus {...props()} />);
-        expect(screen.getByText('Indisponibilité - début - Technique')).toBeInTheDocument();
-    });
-    test('should render fin', () => {
-        const mock = {...actionMock, data: {...actionMock.data, isStart: false}}
-        render(<ActionStatus {...props(mock)} />);
-        expect(screen.queryByText('fin')).toBeNull();
-    });
-    test('should render observations', () => {
-        render(<ActionStatus {...props()} />);
-        expect(screen.getByText('- obs')).toBeInTheDocument();
-    });
-    test('should not render the reason when none', () => {
-        const mock = {...actionMock, data: {...actionMock.data, reason: undefined}}
-        render(<ActionStatus {...props(mock)} />);
-        expect(screen.queryByText('Indisponibilité - début - Technique')).toBeNull();
-        expect(screen.queryByText('Technique')).toBeNull();
-    });
-    test('should not render observations when none', () => {
-        const mock = {...actionMock, data: {...actionMock.data, observations: undefined}}
-        render(<ActionStatus {...props(mock)} />);
-        expect(screen.queryByText('- obs')).toBeNull();
-    });
+  test('should render', () => {
+    render(<ActionStatus {...props()} />);
+    expect(screen.getByText('Indisponibilité - début - Technique')).toBeInTheDocument();
+  });
+  test('should render observations', () => {
+    render(<ActionStatus {...props()} />);
+    expect(screen.getByText('- obs')).toBeInTheDocument();
+  });
+  test('should not render the reason when none', () => {
+    const mock = {...actionMock, data: {...actionMock.data, reason: undefined}}
+    render(<ActionStatus {...props(mock)} />);
+    expect(screen.queryByText('Indisponibilité - début - Technique')).toBeNull();
+    expect(screen.queryByText('Technique')).toBeNull();
+  });
+  test('should not render observations when none', () => {
+    const mock = {...actionMock, data: {...actionMock.data, observations: undefined}}
+    render(<ActionStatus {...props(mock)} />);
+    expect(screen.queryByText('- obs')).toBeNull();
+  });
 
 });

--- a/frontend/src/pam/mission/timeline/item/timeline-item-status.tsx
+++ b/frontend/src/pam/mission/timeline/item/timeline-item-status.tsx
@@ -9,44 +9,44 @@ import { useParams } from 'react-router-dom'
 import { TimelineItemWrapper } from "./timeline-item.tsx";
 
 const ActionStatus: React.FC<{ action: Action; onClick: any }> = ({action, onClick}) => {
-    const {actionId} = useParams()
-    const isSelected = action.id === actionId
-    const actionData = action.data as unknown as NavActionStatus
-    return (
-        <TimelineItemWrapper onClick={onClick} borderWhenSelected={false}>
-            <Stack alignItems="center" spacing="0.5rem">
-                <Stack.Item>
-                    <StatusColorTag status={actionData?.status}/>
-                </Stack.Item>
-                <Stack.Item>
+  const {actionId} = useParams()
+  const isSelected = action.id === actionId
+  const actionData = action.data as unknown as NavActionStatus
+  return (
+    <TimelineItemWrapper onClick={onClick} borderWhenSelected={false}>
+      <Stack alignItems="center" spacing="0.5rem">
+        <Stack.Item>
+          <StatusColorTag status={actionData?.status}/>
+        </Stack.Item>
+        <Stack.Item>
 
-                    <div
-                        style={{
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            maxWidth: '500px'
-                        }}
-                    >
-                        <Text
-                            as="h3"
-                            weight="normal"
-                            color={isSelected ? THEME.color.charcoal : THEME.color.slateGray}
-                            decoration={isSelected ? 'underline' : 'normal'}
-                        >
-                            <b>{`${mapStatusToText(actionData?.status)} - ${actionData?.isStart ? 'début' : 'fin'}${
-                                !!actionData?.reason ? ' - ' + statusReasonToHumanString(actionData?.reason) : ''
-                            }`}</b>
-                            {!!actionData?.observations ? ' - ' + actionData?.observations : ''}
-                        </Text>
-                    </div>
-                </Stack.Item>
-                <Stack.Item>
-                    <Icon.EditUnbordered size={20} color={THEME.color.slateGray}/>
-                </Stack.Item>
-            </Stack>
-        </TimelineItemWrapper>
-    )
+          <div
+            style={{
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              maxWidth: '500px'
+            }}
+          >
+            <Text
+              as="h3"
+              weight="normal"
+              color={isSelected ? THEME.color.charcoal : THEME.color.slateGray}
+              decoration={isSelected ? 'underline' : 'normal'}
+            >
+              <b>{`${mapStatusToText(actionData?.status)} - début${
+                !!actionData?.reason ? ' - ' + statusReasonToHumanString(actionData?.reason) : ''
+              }`}</b>
+              {!!actionData?.observations ? ' - ' + actionData?.observations : ''}
+            </Text>
+          </div>
+        </Stack.Item>
+        <Stack.Item>
+          <Icon.EditUnbordered size={20} color={THEME.color.slateGray}/>
+        </Stack.Item>
+      </Stack>
+    </TimelineItemWrapper>
+  )
 }
 
 export default ActionStatus

--- a/frontend/src/pam/mission/timeline/item/timeline-item.test.tsx
+++ b/frontend/src/pam/mission/timeline/item/timeline-item.test.tsx
@@ -4,58 +4,58 @@ import { ActionTypeEnum, MissionSourceEnum } from "../../../../types/env-mission
 import { Action } from "../../../../types/action-types.ts";
 
 const props = (action: Action) => ({
-    action,
-    onClick: vi.fn()
+  action,
+  onClick: vi.fn()
 })
 describe('MissionTimelineItem', () => {
+  test('should null when actionSource is not supported ', () => {
+    const action = {source: undefined, type: undefined}
+    const {container} = render(<MissionTimelineItem {...props(action)}/>);
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  describe('Env', () => {
     test('should null when actionSource is not supported ', () => {
-        const action = {source: undefined, type: undefined}
-        const {container} = render(<MissionTimelineItem {...props(action)}/>);
-        expect(container.firstElementChild).toBeNull();
+      const action = {source: MissionSourceEnum.MONITORENV, type: undefined}
+      const {container} = render(<MissionTimelineItem {...props(action)}/>);
+      expect(container.firstElementChild).toBeNull();
     });
+    test('should show content for Control', () => {
+      const action = {source: MissionSourceEnum.MONITORENV, type: ActionTypeEnum.CONTROL}
+      render(<MissionTimelineItem {...props(action)}/>);
+      expect(screen.getByText('ajouté par CACEM')).toBeInTheDocument();
+    });
+  });
 
-    describe('Env', () => {
-        test('should null when actionSource is not supported ', () => {
-            const action = {source: MissionSourceEnum.MONITORENV, type: undefined}
-            const {container} = render(<MissionTimelineItem {...props(action)}/>);
-            expect(container.firstElementChild).toBeNull();
-        });
-        test('should show content for Control', () => {
-            const action = {source: MissionSourceEnum.MONITORENV, type: ActionTypeEnum.CONTROL}
-            render(<MissionTimelineItem {...props(action)}/>);
-            expect(screen.getByText('ajouté par CACEM')).toBeInTheDocument();
-        });
+  describe('Fish', () => {
+    test('should null when actionSource is not supported ', () => {
+      const action = {source: MissionSourceEnum.MONITORFISH, type: undefined}
+      const {container} = render(<MissionTimelineItem {...props(action)}/>);
+      expect(container.firstElementChild).toBeNull();
     });
+    test('should show content for Control', () => {
+      const action = {source: MissionSourceEnum.MONITORFISH, type: ActionTypeEnum.CONTROL}
+      render(<MissionTimelineItem {...props(action)}/>);
+      expect(screen.getByText('ajouté par CNSP')).toBeInTheDocument();
+    });
+  });
 
-    describe('Fish', () => {
-        test('should null when actionSource is not supported ', () => {
-            const action = {source: MissionSourceEnum.MONITORFISH, type: undefined}
-            const {container} = render(<MissionTimelineItem {...props(action)}/>);
-            expect(container.firstElementChild).toBeNull();
-        });
-        test('should show content for Control', () => {
-            const action = {source: MissionSourceEnum.MONITORFISH, type: ActionTypeEnum.CONTROL}
-            render(<MissionTimelineItem {...props(action)}/>);
-            expect(screen.getByText('ajouté par CNSP')).toBeInTheDocument();
-        });
+  describe('Nav', () => {
+    test('should null when actionSource is not supported ', () => {
+      const action = {source: MissionSourceEnum.RAPPORTNAV, type: undefined}
+      const {container} = render(<MissionTimelineItem {...props(action)}/>);
+      expect(container.firstElementChild).toBeNull();
     });
-
-    describe('Nav', () => {
-        test('should null when actionSource is not supported ', () => {
-            const action = {source: MissionSourceEnum.RAPPORTNAV, type: undefined}
-            const {container} = render(<MissionTimelineItem {...props(action)}/>);
-            expect(container.firstElementChild).toBeNull();
-        });
-        test('should show content for Control', () => {
-            const action = {source: MissionSourceEnum.RAPPORTNAV, type: ActionTypeEnum.CONTROL}
-            render(<MissionTimelineItem {...props(action)}/>);
-            expect(screen.getByText('Contrôles')).toBeInTheDocument();
-        });
-        test('should show content for Status', () => {
-            const action = {source: MissionSourceEnum.RAPPORTNAV, type: ActionTypeEnum.STATUS}
-            render(<MissionTimelineItem {...props(action)}/>);
-            expect(screen.getByText('Inconnu - fin')).toBeInTheDocument();
-        });
+    test('should show content for Control', () => {
+      const action = {source: MissionSourceEnum.RAPPORTNAV, type: ActionTypeEnum.CONTROL}
+      render(<MissionTimelineItem {...props(action)}/>);
+      expect(screen.getByText('Contrôles')).toBeInTheDocument();
     });
+    test('should show content for Status', () => {
+      const action = {source: MissionSourceEnum.RAPPORTNAV, type: ActionTypeEnum.STATUS}
+      render(<MissionTimelineItem {...props(action)}/>);
+      expect(screen.getByText('Inconnu - début')).toBeInTheDocument();
+    });
+  });
 
 });

--- a/frontend/src/pam/mission/timeline/use-mission-timeline.tsx
+++ b/frontend/src/pam/mission/timeline/use-mission-timeline.tsx
@@ -39,7 +39,6 @@ export const GET_MISSION_TIMELINE = gql`
             startDateTimeUtc
             status
             reason
-            isStart
             observations
           }
           ... on NavActionControl {

--- a/frontend/src/types/action-types.ts
+++ b/frontend/src/types/action-types.ts
@@ -26,7 +26,6 @@ export type ActionStatus = {
   id: string
   status: ActionStatusType
   startDateTimeUtc: string
-  isStart: boolean
   reason?: ActionStatusReason
   observations?: string
 }


### PR DESCRIPTION
C'est par rapport au fait que les commandants voulaient auto-fermer un status quand ils en créent un nouveau.
A la base, on affichait un status de début et un status de fin mais c'était vraiment galère de gérer cette fermeture avec début et fin.
Du coup, on a simplifié et on a que des statuts de début en fait.

Donc quand on remplira le rapport de patrouille, il faudra loop sur tous les statuts et compter les diff entre 2 statuts pour avoir la durée.