### PR TITLE
fix(Trivy): update severity params

### DIFF
--- a/.github/workflows/trivy-db.yml
+++ b/.github/workflows/trivy-db.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run Trivy on Postgres image
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "postgres:15.6-alpine"
+          image-ref: "postgres:15.7-alpine"
           format: sarif
           output: "postgres-trivy-results.sarif"
           severity: "LOW,MEDIUM,HIGH,CRITICAL"

--- a/.github/workflows/trivy-db.yml
+++ b/.github/workflows/trivy-db.yml
@@ -37,7 +37,7 @@ jobs:
           image-ref: "postgres:15.6-alpine"
           format: sarif
           output: "postgres-trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
+          severity: "LOW,MEDIUM,HIGH,CRITICAL"
 
       - name: Upload Postgres Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -79,6 +79,12 @@ jobs:
           output: "trivy-results-os.sarif"
           severity: "LOW,MEDIUM,HIGH,CRITICAL"
 
+      - name: Upload Trivy OS scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results-os.sarif"
+          category: "trivy-os"
+
       - name: Run Trivy on libraries
         uses: aquasecurity/trivy-action@master
         with:
@@ -88,12 +94,8 @@ jobs:
           output: "trivy-results-libs.sarif"
           severity: "HIGH,CRITICAL"
 
-      - name: Upload Trivy OS scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: "trivy-results-os.sarif"
-
       - name: Upload Trivy Library scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "trivy-results-libs.sarif"
+          category: "trivy-libs"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -70,15 +70,30 @@ jobs:
             ENV_PROFILE=${{ env.ENV_PROFILE }}
             GITHUB_SHA=${{ github.sha }}
 
-      - name: Run Trivy on Docker build
+      - name: Run Trivy on OS
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "ghcr.io/mtes-mct/rapportnav2/rapportnav-app:${{ github.sha }}"
           format: sarif
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
+          vuln-type: "os"
+          output: "trivy-results-os.sarif"
+          severity: "LOW,MEDIUM,HIGH,CRITICAL"
 
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Run Trivy on libraries
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "ghcr.io/mtes-mct/rapportnav2/rapportnav-app:${{ github.sha }}"
+          format: sarif
+          vuln-type: "library"
+          output: "trivy-results-libs.sarif"
+          severity: "HIGH,CRITICAL"
+
+      - name: Upload Trivy OS scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: "trivy-results.sarif"
+          sarif_file: "trivy-results-os.sarif"
+
+      - name: Upload Trivy Library scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results-libs.sarif"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ variables:
     value: rapportnav-v2
     description: "Nom du projet à déployer"
   BDD_IAMGE:
-    value: postgres:15.6-alpine
+    value: postgres:15.7-alpine
     description: "Image de la base de données"
   PROJECT_VERSION:
     value: "1.2.0"
@@ -32,7 +32,7 @@ variables:
   FAIL_TRIVY_CONDITION_LIBRARY:
     value: "--severity HIGH,CRITICAL"
     description: "Détermine la commande à passer à Trivy pour bloquer ou non le job. --severity CRITICAL fait échouer le job si Trivy remonte des anomalies critiques."
-  
+
   FAIL_TRIVY_CONDITION_OS:
     value: "--severity LOW,MEDIUM,HIGH,CRITICAL"
     description: "Détermine la commande à passer à Trivy pour bloquer ou non le job. --severity CRITICAL fait échouer le job si Trivy remonte des anomalies critiques."

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/AbstractDBTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/AbstractDBTests.kt
@@ -19,7 +19,7 @@ abstract class AbstractDBTests {
 
     companion object {
         @JvmStatic
-        val container = PostgreSQLContainer("postgres:15.6-alpine")
+        val container = PostgreSQLContainer("postgres:15.7-alpine")
             .apply {
                 withExposedPorts(5432)
                 withEnv("POSTGRES_DB", "testdb")

--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -27,7 +27,7 @@ services:
       - ../frontend:/tmp/frontend
 
   db:
-    image: postgres:15.6-alpine
+    image: postgres:15.7-alpine
     ports:
       - "5432:5432"
     environment:

--- a/jobs-build-CI/deploiement/docker-compose.yml.j2
+++ b/jobs-build-CI/deploiement/docker-compose.yml.j2
@@ -20,7 +20,7 @@ services:
         max-size: "1024m"
 
   db:
-    image: "{{ nexus_proxy }}/postgres:15.6-alpine"
+    image: "{{ nexus_proxy }}/postgres:15.7-alpine"
     volumes:
       - db:/var/lib/postgresql/data
     restart: always


### PR DESCRIPTION
Plusieurs choses ici: 

- updaté les criteres de sévérité histoire de matcher 100% avec la DSI
- séparé l'action Trivy en 2 actions, une qui check l'OS et une autre les libs parce que la DSI fait pareil et n'applique pas les mêmes sévérités selon le cas
- bumpé postres à 15.7


Autre piste d'optimisation:
Pour analyser des images docker, il faut build le container.
Je sais pas pourquoi j'ai fait une usine à gaz qui push un build docker dans notre propre github package manager (https://github.com/MTES-MCT/rapportnav2/pkgs/container/rapportnav2%2Frapportnav-app)
Je pense que c'est absolument pas nécessaire. Build en local et analyser ce build local me parait moins gros que tu push un build sur un package manager