### PR TITLE
refactor(ci): scan file system instead of building a container

### DIFF
--- a/.github/workflows/trivy-db.yml
+++ b/.github/workflows/trivy-db.yml
@@ -35,7 +35,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: "postgres:15.7-alpine"
-          format: sarif
+          format: "sarif"
           output: "postgres-trivy-results.sarif"
           severity: "LOW,MEDIUM,HIGH,CRITICAL"
 
@@ -43,3 +43,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "postgres-trivy-results.sarif"
+          category: "trivy-db"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,51 +30,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Get frontend version
-        uses: avides/actions-project-version-check@v1.4.0
-        id: frontend_version
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          file-to-check: frontend/package.json
-          only-return-version: true
-
-      - name: use-version-from-check
-        run: echo "The version we just got is ${{ steps.frontend_version.outputs.version }}"
-
-      - name: Build image
-        uses: docker/build-push-action@v4
-        env:
-          GITHUB_SHA: ${{ github.sha }}
-          VERSION: ${{ steps.frontend_version.outputs.version }}
-          ENV_PROFILE: "prod"
-        with:
-          context: .
-          builder: ${{ steps.buildx.outputs.name }}
-          file: infra/docker/app/DockerfileCI
-          push: true
-          tags: |
-            ghcr.io/mtes-mct/rapportnav2/rapportnav-app:${{ github.sha }}
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            ENV_PROFILE=${{ env.ENV_PROFILE }}
-            GITHUB_SHA=${{ github.sha }}
-
       - name: Run Trivy on OS
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "ghcr.io/mtes-mct/rapportnav2/rapportnav-app:${{ github.sha }}"
-          format: sarif
+          scan-type: "fs"
+          ignore-unfixed: true
+          format: "sarif"
           vuln-type: "os"
           output: "trivy-results-os.sarif"
           severity: "LOW,MEDIUM,HIGH,CRITICAL"
@@ -88,8 +49,9 @@ jobs:
       - name: Run Trivy on libraries
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: "ghcr.io/mtes-mct/rapportnav2/rapportnav-app:${{ github.sha }}"
-          format: sarif
+          scan-type: "fs"
+          ignore-unfixed: true
+          format: "sarif"
           vuln-type: "library"
           output: "trivy-results-libs.sarif"
           severity: "HIGH,CRITICAL"

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -7,7 +7,7 @@ description = "RapportNav"
 
 val kotlinVersion by extra("1.9.21")
 val serializationVersion by extra("1.6.2")
-val springVersion by extra("3.2.6")
+val springVersion by extra("3.3.0")
 val testcontainersVersion by extra("1.19.3")
 
 plugins {
@@ -16,7 +16,7 @@ plugins {
   kotlin("jvm") version "1.9.21"
   kotlin("plugin.spring") version "1.9.21"
   kotlin("plugin.jpa") version "1.9.21"
-  id("org.springframework.boot") version "3.2.6"
+  id("org.springframework.boot") version "3.3.0"
   id("io.spring.dependency-management") version "1.1.4"
   id("org.owasp.dependencycheck") version "8.4.0"
 //  id("org.sonarqube") version "4.4.1.3373"
@@ -46,9 +46,9 @@ dependencyManagement {
   imports {
     mavenBom("org.testcontainers:testcontainers-bom:$testcontainersVersion")
   }
-  dependencies {
-    dependency("org.springframework.security:spring-security-core:6.2.3")
-  }
+//  dependencies {
+//    dependency("org.springframework.security:spring-security-core:6.2.4")
+//  }
 }
 
 dependencies {
@@ -71,7 +71,7 @@ dependencies {
   }
   implementation("io.jsonwebtoken:jjwt-api:0.12.3")
   implementation("javax.xml.bind:jaxb-api:2.3.1")
-  implementation("org.springframework.security:spring-security-oauth2-jose:6.2.3")
+  implementation("org.springframework.security:spring-security-oauth2-jose:6.3.0")
   implementation("org.locationtech.jts:jts-core:1.19.0")
   implementation("io.swagger.core.v3:swagger-core:2.2.20")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -7,7 +7,7 @@ description = "RapportNav"
 
 val kotlinVersion by extra("1.9.21")
 val serializationVersion by extra("1.6.2")
-val springVersion by extra("3.2.5")
+val springVersion by extra("3.2.6")
 val testcontainersVersion by extra("1.19.3")
 
 plugins {
@@ -16,7 +16,7 @@ plugins {
   kotlin("jvm") version "1.9.21"
   kotlin("plugin.spring") version "1.9.21"
   kotlin("plugin.jpa") version "1.9.21"
-  id("org.springframework.boot") version "3.2.5"
+  id("org.springframework.boot") version "3.2.6"
   id("io.spring.dependency-management") version "1.1.4"
   id("org.owasp.dependencycheck") version "8.4.0"
 //  id("org.sonarqube") version "4.4.1.3373"


### PR DESCRIPTION
Au lieu de faire une usine à gaz et construire une image docker à chaque commit, il s'agit maintenant de scanner le repo: https://github.com/aquasecurity/trivy-action?tab=readme-ov-file#using-trivy-to-scan-your-git-repo