### PR TITLE
feat(polling): add polling 5min on mission timeline query

### DIFF
--- a/frontend/src/pam/mission/crew/mission-crew-member-list.test.tsx
+++ b/frontend/src/pam/mission/crew/mission-crew-member-list.test.tsx
@@ -37,12 +37,12 @@ const crewList = [
 ]
 
 describe('MissionCrewMemberList', () => {
-  it('should render Agent firstname, lastname', async () => {
+  it('should render Agent firstname lastname', async () => {
     render(
       <MissionCrewMemberList crewList={crewList} handleEditCrew={handleEditCrew} handleDeleteCrew={handleDeleteCrew} />
     )
-    expect(screen.getByText('Ivan, Lapierre')).toBeInTheDocument()
-    expect(screen.getByText('Joseph, Dupont')).toBeInTheDocument()
+    expect(screen.getByText('Ivan Lapierre')).toBeInTheDocument()
+    expect(screen.getByText('Joseph Dupont')).toBeInTheDocument()
   })
 
   it('should render comment and active comment icon', async () => {

--- a/frontend/src/pam/mission/timeline/use-mission-timeline.tsx
+++ b/frontend/src/pam/mission/timeline/use-mission-timeline.tsx
@@ -114,7 +114,8 @@ const useGetMissionTimeline = (
   error?: ApolloError
 } => {
   const { loading, error, data } = useQuery(GET_MISSION_TIMELINE, {
-    variables: { missionId }
+    variables: { missionId },
+    pollInterval: 500000 // 5 min
   })
 
   if (!missionId) {


### PR DESCRIPTION
La colonne centrale de l'app ne se met à jour que si une action est faite mais en réalité, c'est pas optimal parce qu'il y a un long temps d'inactivité entre 2 sessions rapportnav pour un commandant. 
Du coup, quand il/elle réouvre rapportnav, les dernieres actions ajoutées par CNSP/CACEM ne sont pas visible, ce qui est un peu confusant.
Lors des retex, c'était assez flag que ca les perturbait.