### PR TITLE
fix(frontend): use correct readonly prop on Fish action form

### DIFF
--- a/frontend/src/features/pam/mission/components/elements/actions/fish/fish-control-administrative-section.tsx
+++ b/frontend/src/features/pam/mission/components/elements/actions/fish/fish-control-administrative-section.tsx
@@ -20,7 +20,7 @@ const FishControlAdministrativeSection: React.FC<FishControlAdministrativeSectio
         <Stack direction="column" alignItems="flex-start" spacing={'1rem'}>
           <Stack.Item>
             <MultiRadio
-              isReadOnly={true}
+              readOnly={true}
               isInline
               label="Bonne émission VMS"
               value={action?.emitsVms ?? undefined}
@@ -31,7 +31,7 @@ const FishControlAdministrativeSection: React.FC<FishControlAdministrativeSectio
           </Stack.Item>
           <Stack.Item>
             <MultiRadio
-              isReadOnly={true}
+              readOnly={true}
               isInline
               value={action?.emitsAis ?? undefined}
               label="Bonne émission AIS"
@@ -42,7 +42,7 @@ const FishControlAdministrativeSection: React.FC<FishControlAdministrativeSectio
           </Stack.Item>
           <Stack.Item>
             <MultiRadio
-              isReadOnly={true}
+              readOnly={true}
               isInline
               label="Déclarations journal de pêche conformes à l'activité du navire"
               value={action?.logbookMatchesActivity ?? undefined}
@@ -53,7 +53,7 @@ const FishControlAdministrativeSection: React.FC<FishControlAdministrativeSectio
           </Stack.Item>
           <Stack.Item>
             <MultiRadio
-              isReadOnly={true}
+              readOnly={true}
               isInline
               label="Autorisations de pêche conformes à l'activité du navire (zone, engins, espèces)"
               value={action?.licencesMatchActivity ?? undefined}

--- a/frontend/src/features/pam/mission/components/elements/actions/fish/fish-control-engines-section.tsx
+++ b/frontend/src/features/pam/mission/components/elements/actions/fish/fish-control-engines-section.tsx
@@ -29,7 +29,7 @@ const FishControlEnginesSection: React.FC<FishControlEnginesSectionProps> = ({ a
             </Stack.Item>
             <Stack.Item>
               <MultiRadio
-                isReadOnly={true}
+                readOnly={true}
                 isInline
                 value={gearControl?.gearWasControlled ?? undefined}
                 label="Engin contrôlé"


### PR DESCRIPTION
On utilisait la mauvaise prop pour passer un form element en readonly