### PR TITLE
fix(frontend): update fish/env text color in timeline

### DIFF
--- a/frontend/src/features/pam/mission/components/elements/timeline/item/timeline-item-control-env.tsx
+++ b/frontend/src/features/pam/mission/components/elements/timeline/item/timeline-item-control-env.tsx
@@ -82,7 +82,7 @@ const ActionEnvControl: React.FC<{ action: Action; onClick: any }> = ({ action, 
                     )}
                   </Stack.Item>
                   <Stack.Item alignSelf="flex-end">
-                    <Text as="h4" color={THEME.color.slateGray} fontStyle={'italic'}>
+                    <Text as="h4" color={THEME.color.mediumSeaGreen} fontStyle={'italic'}>
                       ajouté par CACEM
                     </Text>
                   </Stack.Item>

--- a/frontend/src/features/pam/mission/components/elements/timeline/item/timeline-item-control-fish.tsx
+++ b/frontend/src/features/pam/mission/components/elements/timeline/item/timeline-item-control-fish.tsx
@@ -44,7 +44,7 @@ const ActionFishControl: React.FC<{ action: Action; onClick: any }> = ({ action,
                     )}
                   </Stack.Item>
                   <Stack.Item alignSelf="flex-end">
-                    <Text as="h4" color={THEME.color.slateGray} fontStyle="italic">
+                    <Text as="h4" color={THEME.color.blueGray} fontStyle="italic">
                       ajouté par CNSP
                     </Text>
                   </Stack.Item>

--- a/frontend/src/features/pam/mission/components/elements/timeline/item/timeline-item-surveillance.tsx
+++ b/frontend/src/features/pam/mission/components/elements/timeline/item/timeline-item-surveillance.tsx
@@ -42,7 +42,7 @@ const ActionEnvSurveillance: React.FC<{ action: Action; onClick: any }> = ({ act
               </Stack.Item>
 
               <Stack.Item alignSelf="flex-end" style={{ width: '100%' }}>
-                <Text as="h4" color={THEME.color.slateGray} fontStyle={'italic'} style={{ textAlign: 'right' }}>
+                <Text as="h4" color={THEME.color.mediumSeaGreen} fontStyle={'italic'} style={{ textAlign: 'right' }}>
                   ajouté par CACEM
                 </Text>
               </Stack.Item>


### PR DESCRIPTION
La couleur du texte change pour respecter le "branding" de MonitorEnv et Fish  (sans la bordure, juste le texte)


![Capture d’écran 2024-09-10 à 14 37 47](https://github.com/user-attachments/assets/c4a4ee57-9c77-4dfb-b6bd-5117071abdce)


