### PR TITLE
chore: fix deprecated MockBean in favour of MockitoBean after bumpt t…

### DIFF
--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/auth/TokenServiceTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/auth/TokenServiceTests.kt
@@ -7,30 +7,27 @@ import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.JwtEncoder
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(classes = [TokenService::class])
-class TokenServiceTests  {
+class TokenServiceTests {
 
-    @MockBean
-    private lateinit var jwtDecoder: JwtDecoder;
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
 
-    @MockBean
-    private lateinit var jwtEncoder: JwtEncoder;
+    @MockitoBean
+    private lateinit var jwtEncoder: JwtEncoder
 
-    @MockBean
-    private lateinit var userRepository: IUserRepository;
+    @MockitoBean
+    private lateinit var userRepository: IUserRepository
 
 
-    private val user:User = User(
+    private val user: User = User(
         id = 3,
         firstName = "Jean",
         lastName = "Dupont",
@@ -38,17 +35,17 @@ class TokenServiceTests  {
         password = "MyBeautifulPassword",
         serviceId = 6,
         roles = listOf(RoleTypeEnum.USER_ULAM)
-    );
+    )
 
 
     @Test
     fun `execute should have roles with claim user id and user role`() {
-        val tokenService = TokenService(jwtDecoder, jwtEncoder, userRepository);
-        val claims = tokenService.getClaims(user);
-        assertThat(claims).isNotNull();
+        val tokenService = TokenService(jwtDecoder, jwtEncoder, userRepository)
+        val claims = tokenService.getClaims(user)
+        assertThat(claims).isNotNull()
 
-        assertThat(claims.getClaim<Int>("userId")).isEqualTo(user.id);
-        assertThat(claims.getClaim<List<RoleTypeEnum>>("roles")).isEqualTo(user.roles);
+        assertThat(claims.getClaim<Int>("userId")).isEqualTo(user.id)
+        assertThat(claims.getClaim<List<RoleTypeEnum>>("roles")).isEqualTo(user.roles)
     }
 
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetEnvMissionByIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetEnvMissionByIdTest.kt
@@ -20,13 +20,13 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 @SpringBootTest(classes = [GetEnvMissionById::class])
@@ -48,16 +48,16 @@ class GetEnvMissionByIdTest {
     @Autowired
     private lateinit var cacheManager: CacheManager
 
-    @MockBean
+    @MockitoBean
     private lateinit var getEnvMissions: GetEnvMissions
 
-    @MockBean
+    @MockitoBean
     private lateinit var monitorEnvApiRepo: IEnvMissionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var attachControlsToActionControl: AttachControlsToActionControl
 
-    @MockBean
+    @MockitoBean
     private lateinit var getFakeActionData: FakeActionData
 
     private val envControlActionId: UUID = UUID.randomUUID()

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetEnvMissionsTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetEnvMissionsTest.kt
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [GetEnvMissions::class])
 @ContextConfiguration(classes = [GetEnvMissionsTest.TestConfig::class])
@@ -36,7 +36,7 @@ class GetEnvMissionsTest {
     @Autowired
     private lateinit var cacheManager: CacheManager
 
-    @MockBean
+    @MockitoBean
     private lateinit var envMissionRepository: IEnvMissionRepository
 
     private val mockEnvMissions = listOf(

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetFishActionsByMissionIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetFishActionsByMissionIdTest.kt
@@ -12,13 +12,13 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [GetFishActionsByMissionId::class])
 @ContextConfiguration(classes = [GetFishActionsByMissionIdTest.TestConfig::class])
@@ -39,14 +39,14 @@ class GetFishActionsByMissionIdTest {
     @Autowired
     private lateinit var cacheManager: CacheManager
 
-    @MockBean
+    @MockitoBean
     private lateinit var fishActionRepo: IFishActionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var attachControlsToActionControl: AttachControlsToActionControl
 
-    @MockBean
-    private lateinit  var getFakeActionData: FakeActionData
+    @MockitoBean
+    private lateinit var getFakeActionData: FakeActionData
 
     private val mockFishMissionActions = listOf(
         FishActionControlMock.create(id = 1),

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetNavMissionByIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/GetNavMissionByIdTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [GetNavMissionById::class])
 class GetNavMissionByIdTest {
@@ -21,7 +21,7 @@ class GetNavMissionByIdTest {
     @Autowired
     private lateinit var getMissionNavById: GetNavMissionById
 
-    @MockBean
+    @MockitoBean
     private lateinit var getServiceByControlUnit: GetServiceByControlUnit
 
     private val controlUnits: List<LegacyControlUnitEntity> = listOf(
@@ -33,46 +33,46 @@ class GetNavMissionByIdTest {
         )
     )
 
-    @MockBean
-    private lateinit var navActionControlRepository: INavActionControlRepository;
+    @MockitoBean
+    private lateinit var navActionControlRepository: INavActionControlRepository
 
-    @MockBean
-    private lateinit var navStatusRepository: INavActionStatusRepository;
+    @MockitoBean
+    private lateinit var navStatusRepository: INavActionStatusRepository
 
-    @MockBean
-    private lateinit var navFreeNoteRepository: INavActionFreeNoteRepository;
+    @MockitoBean
+    private lateinit var navFreeNoteRepository: INavActionFreeNoteRepository
 
-    @MockBean
-    private lateinit var attachControlsToActionControl: AttachControlsToActionControl;
+    @MockitoBean
+    private lateinit var attachControlsToActionControl: AttachControlsToActionControl
 
-    @MockBean
-    private lateinit var getMissionGeneralInfoByMissionId: GetMissionGeneralInfoByMissionId;
+    @MockitoBean
+    private lateinit var getMissionGeneralInfoByMissionId: GetMissionGeneralInfoByMissionId
 
-    @MockBean
-    private lateinit var getAgentsCrewByMissionId: GetAgentsCrewByMissionId;
+    @MockitoBean
+    private lateinit var getAgentsCrewByMissionId: GetAgentsCrewByMissionId
 
-    @MockBean
-    private lateinit var navRescueRepository: INavActionRescueRepository;
+    @MockitoBean
+    private lateinit var navRescueRepository: INavActionRescueRepository
 
-    @MockBean
-    private lateinit var navNauticalEventRepository: INavActionNauticalEventRepository;
+    @MockitoBean
+    private lateinit var navNauticalEventRepository: INavActionNauticalEventRepository
 
-    @MockBean
-    private lateinit var navVigimerRepository: INavActionVigimerRepository;
+    @MockitoBean
+    private lateinit var navVigimerRepository: INavActionVigimerRepository
 
-    @MockBean
-    private lateinit var navAntiPollutionRepository: INavActionAntiPollutionRepository;
+    @MockitoBean
+    private lateinit var navAntiPollutionRepository: INavActionAntiPollutionRepository
 
-    @MockBean
-    private lateinit var navBAAEMRepository: INavActionBAAEMRepository;
+    @MockitoBean
+    private lateinit var navBAAEMRepository: INavActionBAAEMRepository
 
-    @MockBean
-    private lateinit var navPublicOrderRepository: INavActionPublicOrderRepository;
+    @MockitoBean
+    private lateinit var navPublicOrderRepository: INavActionPublicOrderRepository
 
-    @MockBean
-    private lateinit var navRepresentationRepository: INavActionRepresentationRepository;
+    @MockitoBean
+    private lateinit var navRepresentationRepository: INavActionRepresentationRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var navIllegalImmigrationRepository: INavActionIllegalImmigrationRepository
 
     private val serviceEntities: List<ServiceEntity> = listOf(
@@ -85,17 +85,17 @@ class GetNavMissionByIdTest {
             name = "SecondService",
             controlUnits = listOf(3, 4)
         )
-    );
+    )
 
     @Test
     fun `execute should have services in nav mission entity`() {
-        Mockito.`when`(getServiceByControlUnit.execute(controlUnits)).thenReturn(serviceEntities);
+        Mockito.`when`(getServiceByControlUnit.execute(controlUnits)).thenReturn(serviceEntities)
         val response = getMissionNavById.execute(2, controlUnits)
 
-        assertThat(response).isNotNull();
-        assertThat(response.services).isNotNull();
-        assertThat(response.services?.size).isEqualTo(2);
-        assertThat(response.services?.map { service -> service.id }).containsAll(listOf(3, 4));
+        assertThat(response).isNotNull()
+        assertThat(response.services).isNotNull()
+        assertThat(response.services?.size).isEqualTo(2)
+        assertThat(response.services?.map { service -> service.id }).containsAll(listOf(3, 4))
     }
 
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/PatchEnvMissionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/PatchEnvMissionTest.kt
@@ -10,28 +10,28 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [PatchEnvMission::class])
 class PatchEnvMissionTest {
     @Autowired
     private lateinit var patchEnvMission: PatchEnvMission
 
-    @MockBean
+    @MockitoBean
     private lateinit var envRepository: IEnvMissionRepository
 
     @Test
     fun `execute update env mission with ObservationByUnit`() {
-        val missionId = 761;
-        val observationsByUnit = "MyBeautifulObservation";
-        val mission = EnvMissionMock.create(observationsByUnit = observationsByUnit);
-        val missionEnvEntity = PatchMissionInput(observationsByUnit = observationsByUnit);
+        val missionId = 761
+        val observationsByUnit = "MyBeautifulObservation"
+        val mission = EnvMissionMock.create(observationsByUnit = observationsByUnit)
+        val missionEnvEntity = PatchMissionInput(observationsByUnit = observationsByUnit)
 
-        Mockito.`when`(envRepository.patchMission(missionId, missionEnvEntity)).thenReturn(mission);
+        Mockito.`when`(envRepository.patchMission(missionId, missionEnvEntity)).thenReturn(mission)
         val response =
-            patchEnvMission.execute(MissionEnvInput(missionId = missionId, observationsByUnit = observationsByUnit));
-        assertThat(response).isNotNull();
-        assertThat(response?.observationsByUnit).isEqualTo(observationsByUnit);
+            patchEnvMission.execute(MissionEnvInput(missionId = missionId, observationsByUnit = observationsByUnit))
+        assertThat(response).isNotNull()
+        assertThat(response?.observationsByUnit).isEqualTo(observationsByUnit)
 
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/UpdateMissionServiceTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/UpdateMissionServiceTest.kt
@@ -1,6 +1,5 @@
 package fr.gouv.gmampa.rapportnav.domain.use_cases.mission
 
-import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.ServiceEntity
 import fr.gouv.dgampa.rapportnav.domain.repositories.mission.crew.IAgentServiceRepository
 import fr.gouv.dgampa.rapportnav.domain.repositories.mission.crew.IMissionCrewRepository
 import fr.gouv.dgampa.rapportnav.domain.repositories.mission.crew.IServiceRepository
@@ -18,7 +17,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 @SpringBootTest(classes = [UpdateMissionService::class])
@@ -26,17 +25,17 @@ class UpdateMissionServiceTest {
     @Autowired
     private lateinit var updateMissionService: UpdateMissionService
 
-    @MockBean
-    private lateinit var serviceRepo: IServiceRepository;
+    @MockitoBean
+    private lateinit var serviceRepo: IServiceRepository
 
-    @MockBean
-    private lateinit var missionCrewRepo: IMissionCrewRepository;
+    @MockitoBean
+    private lateinit var missionCrewRepo: IMissionCrewRepository
 
-    @MockBean
-    private lateinit var infoRepo: IMissionGeneralInfoRepository;
+    @MockitoBean
+    private lateinit var infoRepo: IMissionGeneralInfoRepository
 
-    @MockBean
-    private lateinit var agentServiceRepo: IAgentServiceRepository;
+    @MockitoBean
+    private lateinit var agentServiceRepo: IAgentServiceRepository
 
     private val oldMissionCrews: List<MissionCrewModel> = listOf(
         MissionCrewModel(
@@ -67,30 +66,30 @@ class UpdateMissionServiceTest {
             consumedGOInLiters = 2.5f,
             distanceInNauticalMiles = 1.9f
 
-        );
+        )
         val input = MissionServiceInput(missionId = 761, serviceId = 3)
-        val serviceModel = ServiceModel(id = 3, name="Themis_A");
-        Mockito.`when`(serviceRepo.findById(3)).thenReturn(Optional.of(serviceModel));
-        Mockito.`when`(agentServiceRepo.findByServiceId(3)).thenReturn(newMissionCrews);
-        Mockito.`when`(missionCrewRepo.findByMissionId(761)).thenReturn(oldMissionCrews);
-        Mockito.`when`(infoRepo.findByMissionId(761)).thenReturn(Optional.of(missionGeneralInfo));
+        val serviceModel = ServiceModel(id = 3, name = "Themis_A")
+        Mockito.`when`(serviceRepo.findById(3)).thenReturn(Optional.of(serviceModel))
+        Mockito.`when`(agentServiceRepo.findByServiceId(3)).thenReturn(newMissionCrews)
+        Mockito.`when`(missionCrewRepo.findByMissionId(761)).thenReturn(oldMissionCrews)
+        Mockito.`when`(infoRepo.findByMissionId(761)).thenReturn(Optional.of(missionGeneralInfo))
 
-        val response = updateMissionService.execute(input);
-        assertThat(response).isNotNull();
-        assertThat(response?.id).isEqualTo(3);
+        val response = updateMissionService.execute(input)
+        assertThat(response).isNotNull()
+        assertThat(response?.id).isEqualTo(3)
     }
 
     @Test
     fun `execute update mission service event if generalInfo is null`() {
         val input = MissionServiceInput(missionId = 761, serviceId = 3)
-        val serviceModel = ServiceModel(id = 3, name="Themis_A");
-        Mockito.`when`(serviceRepo.findById(3)).thenReturn(Optional.of(serviceModel));
-        Mockito.`when`(agentServiceRepo.findByServiceId(3)).thenReturn(newMissionCrews);
-        Mockito.`when`(missionCrewRepo.findByMissionId(761)).thenReturn(oldMissionCrews);
-        Mockito.`when`(infoRepo.findByMissionId(761)).thenReturn(Optional.ofNullable(null));
+        val serviceModel = ServiceModel(id = 3, name = "Themis_A")
+        Mockito.`when`(serviceRepo.findById(3)).thenReturn(Optional.of(serviceModel))
+        Mockito.`when`(agentServiceRepo.findByServiceId(3)).thenReturn(newMissionCrews)
+        Mockito.`when`(missionCrewRepo.findByMissionId(761)).thenReturn(oldMissionCrews)
+        Mockito.`when`(infoRepo.findByMissionId(761)).thenReturn(Optional.ofNullable(null))
 
-        val response = updateMissionService.execute(input);
-        assertThat(response).isNotNull();
-        assertThat(response?.id).isEqualTo(3);
+        val response = updateMissionService.execute(input)
+        assertThat(response).isNotNull()
+        assertThat(response?.id).isEqualTo(3)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/CreateNavActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/CreateNavActionTest.kt
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.util.*
 
@@ -26,12 +26,12 @@ import java.util.*
 @SpringBootTest(classes = [CreateNavAction::class])
 @ContextConfiguration(classes = [CreateNavAction::class])
 class CreateNavActionTest {
-    @MockBean
+    @MockitoBean
     private lateinit var missionActionRepository: INavMissionActionRepository
 
     @Test
     fun `test execute create nav action`() {
-        val actionId =  UUID.randomUUID().toString()
+        val actionId = UUID.randomUUID().toString()
         val input = MissionNavAction(
             id = actionId,
             missionId = 761,

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/DeleteNavActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/DeleteNavActionTest.kt
@@ -4,25 +4,22 @@ import fr.gouv.dgampa.rapportnav.domain.repositories.mission.action.INavMissionA
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.DeleteNavAction
 import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doNothing
-import org.mockito.kotlin.doReturn
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 
 @SpringBootTest(classes = [DeleteNavAction::class])
 @ContextConfiguration(classes = [DeleteNavAction::class])
 class DeleteNavActionTest {
-    @MockBean
+    @MockitoBean
     private lateinit var missionActionRepository: INavMissionActionRepository
 
     @Test
     fun `test execute delete nav action`() {
-        val actionId =  UUID.randomUUID()
+        val actionId = UUID.randomUUID()
         doNothing().`when`(missionActionRepository).deleteById(actionId)
 
         val deleteNavAction = DeleteNavAction(

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetAllControlPlansTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetAllControlPlansTest.kt
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [GetAllControlPlans::class])
 @ContextConfiguration(classes = [GetAllControlPlansTest.TestConfig::class])
@@ -36,7 +36,7 @@ class GetAllControlPlansTest {
     @Autowired
     private lateinit var cacheManager: CacheManager
 
-    @MockBean
+    @MockitoBean
     private lateinit var envMissionRepository: IEnvMissionRepository
 
     private val mockControlPlans = ControlPlansEntity(

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetEnvActionByIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetEnvActionByIdTest.kt
@@ -17,8 +17,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.util.*
 
@@ -29,19 +29,19 @@ class GetEnvActionByIdTest {
     @Autowired
     private lateinit var getEnvActionById: GetEnvActionById
 
-    @MockBean
+    @MockitoBean
     private lateinit var monitorEnvApiRepo: IEnvMissionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var getControlByActionId: GetControlByActionId2
 
-    @MockBean
+    @MockitoBean
     private lateinit var getStatusForAction: GetStatusForAction
 
-    @MockBean
+    @MockitoBean
     private lateinit var mapControlPlans: MapEnvActionControlPlans
 
-    @MockBean
+    @MockitoBean
     private lateinit var getInfractionsByActionId: GetInfractionsByActionId
 
     @Test
@@ -63,7 +63,7 @@ class GetEnvActionByIdTest {
             missionSource = MissionSourceEnum.MONITORENV
         )
 
-        val mockControl  = ControlMock.createAllControl()
+        val mockControl = ControlMock.createAllControl()
 
         `when`(getControlByActionId.getAllControl(anyOrNull())).thenReturn(mockControl)
         `when`(monitorEnvApiRepo.findMissionById(missionId)).thenReturn(missionEntity)

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetEnvActionListByMissionIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetEnvActionListByMissionIdTest.kt
@@ -18,8 +18,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.util.*
 
@@ -30,23 +30,23 @@ class GetEnvActionListByMissionIdTest {
     @Autowired
     private lateinit var getEnvActionListById: GetEnvActionListByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var monitorEnvApiRepo: IEnvMissionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var getControlByActionId: GetControlByActionId2
 
-    @MockBean
+    @MockitoBean
     private lateinit var getStatusForAction: GetStatusForAction
 
-    @MockBean
+    @MockitoBean
     private lateinit var mapControlPlans: MapEnvActionControlPlans
 
-    @MockBean
+    @MockitoBean
     private lateinit var getInfractionsByActionId: GetInfractionsByActionId
 
-    @MockBean
-    private  lateinit var  getFakeActionData: FakeActionData
+    @MockitoBean
+    private lateinit var getFakeActionData: FakeActionData
 
     @Test
     fun `test execute get Env action list  by mission id`() {
@@ -67,7 +67,7 @@ class GetEnvActionListByMissionIdTest {
             missionSource = MissionSourceEnum.MONITORENV
         )
 
-        val mockControl  = ControlMock.createAllControl()
+        val mockControl = ControlMock.createAllControl()
 
         `when`(getControlByActionId.getAllControl(anyOrNull())).thenReturn(mockControl)
         `when`(monitorEnvApiRepo.findMissionById(missionId)).thenReturn(missionEntity)

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetFishActionByIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetFishActionByIdTest.kt
@@ -12,8 +12,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 @SpringBootTest(classes = [GetFishActionById::class])
@@ -23,13 +23,13 @@ class GetFishActionByIdTest {
     @Autowired
     private lateinit var getFishActionById: GetFishActionById
 
-    @MockBean
+    @MockitoBean
     private lateinit var fishActionRepo: IFishActionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var getControlByActionId: GetControlByActionId2
 
-    @MockBean
+    @MockitoBean
     private lateinit var getStatusForAction: GetStatusForAction
 
     @Test
@@ -41,7 +41,7 @@ class GetFishActionByIdTest {
             id = actionId,
         )
 
-        val mockControl  = ControlMock.createAllControl()
+        val mockControl = ControlMock.createAllControl()
 
         `when`(getControlByActionId.getAllControl(anyOrNull())).thenReturn(mockControl)
         `when`(fishActionRepo.findFishActions(missionId)).thenReturn(listOf(action))

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetFishActionListByMissionIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetFishActionListByMissionIdTest.kt
@@ -13,8 +13,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 @SpringBootTest(classes = [GetFishActionListByMissionId::class])
@@ -24,18 +24,18 @@ class GetFishActionListByMissionIdTest {
     @Autowired
     private lateinit var getFishActionList: GetFishActionListByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var fishActionRepo: IFishActionRepository
 
 
-    @MockBean
+    @MockitoBean
     private lateinit var getStatusForAction: GetStatusForAction
 
-    @MockBean
+    @MockitoBean
     private lateinit var getControlByActionId: GetControlByActionId2
 
-    @MockBean
-    private  lateinit var  getFakeActionData: FakeActionData
+    @MockitoBean
+    private lateinit var getFakeActionData: FakeActionData
 
     @Test
     fun `test execute get Fish action list  by mission id`() {
@@ -46,7 +46,7 @@ class GetFishActionListByMissionIdTest {
             id = actionId,
         )
 
-        val mockControl  = ControlMock.createAllControl()
+        val mockControl = ControlMock.createAllControl()
 
         `when`(getControlByActionId.getAllControl(anyOrNull())).thenReturn(mockControl)
         `when`(fishActionRepo.findFishActions(missionId)).thenReturn(listOf(action))

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetNavActionByIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetNavActionByIdTest.kt
@@ -9,13 +9,12 @@ import fr.gouv.dgampa.rapportnav.infrastructure.database.model.mission.action.v2
 import fr.gouv.gmampa.rapportnav.mocks.mission.action.ControlMock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.util.*
 
@@ -26,13 +25,13 @@ class GetNavActionByIdTest {
     @Autowired
     private lateinit var getNavActionById: GetNavActionById
 
-    @MockBean
+    @MockitoBean
     private lateinit var missionActionRepository: INavMissionActionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var getControlByActionId: GetControlByActionId2
 
-    @MockBean
+    @MockitoBean
     private lateinit var getStatusForAction: GetStatusForAction
 
     @Test
@@ -74,7 +73,7 @@ class GetNavActionByIdTest {
             actionType = ActionType.CONTROL,
         )
 
-        val mockControl  = ControlMock.createAllControl()
+        val mockControl = ControlMock.createAllControl()
 
         `when`(getControlByActionId.getAllControl(anyOrNull())).thenReturn(mockControl)
         `when`(missionActionRepository.findById(actionId)).thenReturn(Optional.of(action))

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetNavActionListByMissionIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/GetNavActionListByMissionIdTest.kt
@@ -13,8 +13,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.util.*
 
@@ -25,13 +25,13 @@ class GetNavActionListByMissionIdTest {
     @Autowired
     private lateinit var getNavActionList: GetNavActionListByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var navMissionActionRepository: INavMissionActionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var getControlByActionId: GetControlByActionId2
 
-    @MockBean
+    @MockitoBean
     private lateinit var getStatusForAction: GetStatusForAction
 
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/MapEnvActionControlPlansTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/MapEnvActionControlPlansTests.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 
 @SpringBootTest(classes = [MapEnvActionControlPlans::class])
@@ -20,7 +20,7 @@ class MapEnvActionControlPlansTest {
     @Autowired
     private lateinit var mapEnvActionControlPlans: MapEnvActionControlPlans
 
-    @MockBean
+    @MockitoBean
     private lateinit var getAllControlPlans: GetAllControlPlans
 
     private val controlPlanFromEnvAction1 = EnvActionControlPlanEntity(

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/ProcessMissionActionControlTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/ProcessMissionActionControlTest.kt
@@ -17,27 +17,27 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 @SpringBootTest(classes = [ProcessMissionActionControl::class])
 @ContextConfiguration(classes = [ProcessMissionActionControl::class])
 class ProcessMissionActionControlTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionControl: ProcessMissionActionControl
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlSecurityRepo: IControlSecurityRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlNavigationRepo: IControlNavigationRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlGensDeMerRepo: IControlGensDeMerRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlAdministrativeRepo: IControlAdministrativeRepository
 
     @Test
@@ -48,7 +48,10 @@ class ProcessMissionActionControlTest {
         input.controlGensDeMer?.setMissionIdAndActionId(actionId = action.id.toString(), missionId = action.missionId)
         input.controlSecurity?.setMissionIdAndActionId(actionId = action.id.toString(), missionId = action.missionId)
         input.controlNavigation?.setMissionIdAndActionId(actionId = action.id.toString(), missionId = action.missionId)
-        input.controlAdministrative?.setMissionIdAndActionId(actionId = action.id.toString(), missionId = action.missionId)
+        input.controlAdministrative?.setMissionIdAndActionId(
+            actionId = action.id.toString(),
+            missionId = action.missionId
+        )
 
         val controls = input.toActionControlEntity()
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/ProcessMissionActionInfractionEnvTargetTest .kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/ProcessMissionActionInfractionEnvTargetTest .kt
@@ -19,8 +19,8 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 
@@ -28,10 +28,10 @@ import java.util.*
 @ContextConfiguration(classes = [ProcessMissionActionInfractionEnvTarget::class])
 class ProcessMissionActionInfractionEnvTargetTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var infractionRepo: IInfractionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var infractionEnvTargetRepo: IInfractionEnvTargetRepository
 
     @Captor
@@ -40,7 +40,7 @@ class ProcessMissionActionInfractionEnvTargetTest {
     @Captor
     lateinit var saveCaptor: ArgumentCaptor<List<Infraction>>
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionInfractionEnvTarget: ProcessMissionActionInfractionEnvTarget
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/ProcessMissionActionInfractionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/ProcessMissionActionInfractionTest.kt
@@ -20,8 +20,8 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.*
 
 
@@ -29,7 +29,7 @@ import java.util.*
 @ContextConfiguration(classes = [ProcessMissionActionInfraction::class])
 class ProcessMissionActionInfractionTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var infractionRepo: IInfractionRepository
 
     @Captor
@@ -38,7 +38,7 @@ class ProcessMissionActionInfractionTest {
     @Captor
     lateinit var saveCaptor: ArgumentCaptor<List<InfractionEntity>>
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionInfraction: ProcessMissionActionInfraction
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/UpdateEnvActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/UpdateEnvActionTest.kt
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.util.*
 
@@ -24,21 +24,22 @@ import java.util.*
 @ContextConfiguration(classes = [UpdateEnvAction::class])
 class UpdateEnvActionTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var patchEnvAction: PatchEnvAction
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionControl: ProcessMissionActionControl
 
-    @MockBean lateinit var processMissionActionControlEnvTarget : ProcessMissionActionControlEnvTarget
+    @MockitoBean
+    lateinit var processMissionActionControlEnvTarget: ProcessMissionActionControlEnvTarget
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionInfractionEnvTarget: ProcessMissionActionInfractionEnvTarget
 
 
     @Test
     fun `test execute update env action`() {
-        val actionId =  UUID.randomUUID().toString()
+        val actionId = UUID.randomUUID().toString()
         val input = MissionEnvAction(
             id = actionId,
             missionId = 761,

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/UpdateFishActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/UpdateFishActionTest.kt
@@ -15,27 +15,27 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 
 @SpringBootTest(classes = [UpdateFishAction::class])
 @ContextConfiguration(classes = [UpdateFishAction::class])
 class UpdateFishActionTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var patchFishAction: PatchFishAction
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionControl: ProcessMissionActionControl
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionInfraction: ProcessMissionActionInfraction
 
 
     @Test
     fun `test execute update fish action`() {
-        val actionId =  54566.toString()
+        val actionId = 54566.toString()
         val input = MissionFishAction(
             id = actionId,
             missionId = 761,

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/UpdateNavActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/UpdateNavActionTest.kt
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.util.*
 
@@ -29,19 +29,19 @@ import java.util.*
 @ContextConfiguration(classes = [UpdateNavAction::class])
 class UpdateNavActionTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var missionActionRepository: INavMissionActionRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionControl: ProcessMissionActionControl
 
-    @MockBean
+    @MockitoBean
     private lateinit var processMissionActionInfraction: ProcessMissionActionInfraction
 
 
     @Test
     fun `test execute update nav action`() {
-        val actionId =  UUID.randomUUID().toString()
+        val actionId = UUID.randomUUID().toString()
         val input = MissionNavAction(
             id = actionId,
             missionId = 761,

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/control/AddOrProcessControlTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/control/AddOrProcessControlTest.kt
@@ -19,7 +19,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.*
 
@@ -28,19 +28,19 @@ import java.util.*
 @SpringBootTest(classes = [AddOrUpdateControl::class])
 class AddOrProcessControlTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlAdministrativeRepo: IControlAdministrativeRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlSecurityRepo: IControlSecurityRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlNavigationRepo: IControlNavigationRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var controlGensDeMerRepo: IControlGensDeMerRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var getControlByActionId: GetControlByActionId
 
     @Autowired

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/crew/GetAgentsCrewByMissionIdTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/crew/GetAgentsCrewByMissionIdTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [GetAgentsCrewByMissionId::class])
 class GetAgentsCrewByMissionIdTest {
@@ -18,7 +18,7 @@ class GetAgentsCrewByMissionIdTest {
     @Autowired
     private lateinit var getAgentsCrewByMissionId: GetAgentsCrewByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var agentCrewRepository: IMissionCrewRepository
 
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/crew/GetServiceByControlUnitTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/crew/GetServiceByControlUnitTest.kt
@@ -1,26 +1,23 @@
 package fr.gouv.gmampa.rapportnav.domain.use_cases.mission.crew
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.controlResources.LegacyControlUnitEntity
-import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.controlResources.LegacyControlUnitResourceEntity
 import fr.gouv.dgampa.rapportnav.domain.repositories.mission.crew.IServiceRepository
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetServiceByControlUnit
 import fr.gouv.dgampa.rapportnav.infrastructure.database.model.mission.ServiceModel
-import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.interfaces.mission.crew.IDBServiceRepository
-import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew.JPAServiceRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(classes = [GetServiceByControlUnit::class])
 class GetServiceByControlUnitTest {
 
-    @MockBean
-    private lateinit var serviceRepository: IServiceRepository;
+    @MockitoBean
+    private lateinit var serviceRepository: IServiceRepository
 
 
     private val serviceModels: List<ServiceModel> = listOf(
@@ -33,7 +30,7 @@ class GetServiceByControlUnitTest {
             name = "SecondService",
             controlUnits = listOf(3, 4)
         )
-    );
+    )
 
     private val controlUnits: List<LegacyControlUnitEntity> = listOf(
         LegacyControlUnitEntity(
@@ -47,15 +44,15 @@ class GetServiceByControlUnitTest {
 
     @Test
     fun `execute should retrieve serviceModel with control units list`() {
-        Mockito.`when`(serviceRepository.findByControlUnitId(listOf(3))).thenReturn(serviceModels);
+        Mockito.`when`(serviceRepository.findByControlUnitId(listOf(3))).thenReturn(serviceModels)
         val getServiceByControlUnit = GetServiceByControlUnit(serviceRepository)
         val response = getServiceByControlUnit.execute(controlUnits)
 
-        assertThat(response).isNotNull();
-        assertThat(response.size).isEqualTo(2);
-        assertThat(response.map { service -> service.id }).containsAll(listOf(3, 4));
-        assertThat(response.get(0).id).isEqualTo(3);
-        assertThat(response.get(1).id).isEqualTo(4);
+        assertThat(response).isNotNull()
+        assertThat(response.size).isEqualTo(2)
+        assertThat(response.map { service -> service.id }).containsAll(listOf(3, 4))
+        assertThat(response.get(0).id).isEqualTo(3)
+        assertThat(response.get(1).id).isEqualTo(4)
 
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/ExportMissionAEMTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/ExportMissionAEMTests.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 
 @SpringBootTest(classes = [ExportMissionAEM::class])
@@ -21,10 +21,10 @@ class ExportMissionAEMTests {
     @Autowired
     private lateinit var exportMissionAEM: ExportMissionAEM
 
-    @MockBean
+    @MockitoBean
     private lateinit var fillAEMExcelRow: FillAEMExcelRow
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMissionById: GetMission
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/ExportMissionRapportPatrouilleTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/ExportMissionRapportPatrouilleTests.kt
@@ -21,7 +21,7 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(
     classes = [
@@ -39,22 +39,22 @@ class ExportMissionRapportPatrouilleTests {
     @Autowired
     private lateinit var exportMissionRapportPatrouille: ExportMissionRapportPatrouille
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMissionGeneralInfoByMissionId: GetMissionGeneralInfoByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var agentsCrewByMissionId: GetAgentsCrewByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMission: GetMission
 
-    @MockBean
+    @MockitoBean
     private lateinit var navActionStatus: INavActionStatusRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var formatActionsForTimeline: FormatActionsForTimeline
 
-    @MockBean
+    @MockitoBean
     private lateinit var getServiceById: GetServiceById
 
     @BeforeEach

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/FillAEMExcelRowTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/FillAEMExcelRowTest.kt
@@ -9,42 +9,42 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [FillAEMExcelRow::class])
 class FillAEMExcelRowTest {
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportExcelFile: ExportExcelFile
 
     @Autowired
     private lateinit var fillAEMExcelRow: FillAEMExcelRow
 
-    @MockBean
+    @MockitoBean
     private lateinit var tableExport: AEMTableExport
 
-    @MockBean
+    @MockitoBean
     private lateinit var migrationRescue: AEMMigrationRescue
 
-    @MockBean
+    @MockitoBean
     private lateinit var outOfMigrationRescue: AEMOutOfMigrationRescue
 
-    @MockBean
+    @MockitoBean
     private lateinit var vesselRescue: AEMVesselRescue
 
-    @MockBean
+    @MockitoBean
     private lateinit var envTraffic: AEMEnvTraffic
 
-    @MockBean
+    @MockitoBean
     private lateinit var notPollControlSurveillance: AEMNotPollutionControlSurveillance
 
-    @MockBean
+    @MockitoBean
     private lateinit var pollutionControlSurveillance: AEMPollutionControlSurveillance
 
-    @MockBean
+    @MockitoBean
     private lateinit var illegalFish: AEMIllegalFish
 
-    @MockBean
+    @MockitoBean
     private lateinit var sovereignProtect: AEMSovereignProtect
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/FormatActionsForTimelineTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/FormatActionsForTimelineTests.kt
@@ -20,7 +20,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 import java.time.LocalDate
 
@@ -30,10 +30,10 @@ class FormatActionsForTimelineTests {
     @Autowired
     private lateinit var formatActionsForTimeline: FormatActionsForTimeline
 
-    @MockBean
+    @MockitoBean
     private lateinit var groupActionByDate: GroupActionByDate
 
-    @MockBean
+    @MockitoBean
     private lateinit var mapEnvActionControlPlans: MapEnvActionControlPlans
 
     private val envControl =

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/MapStatusDurationsTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/MapStatusDurationsTests.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 
 @SpringBootTest(classes = [MapStatusDurations::class])
@@ -20,7 +20,7 @@ class MapStatusDurationsTests {
     @Autowired
     private lateinit var mapStatusDurations: MapStatusDurations
 
-    @MockBean
+    @MockitoBean
     private lateinit var getStatusDurations: GetStatusDurations
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionAEMSingleTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionAEMSingleTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [ExportMissionAEMSingle::class, FormatDateTime::class])
 class ExportMissionAEMSingleTest {
@@ -21,10 +21,10 @@ class ExportMissionAEMSingleTest {
     @Autowired
     private lateinit var exportMissionListAEM: ExportMissionAEMSingle
 
-    @MockBean
+    @MockitoBean
     private lateinit var fillAEMExcelRow: FillAEMExcelRow
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMissionById: GetMission
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolCombinedTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolCombinedTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [ExportMissionPatrolCombined::class, FormatDateTime::class])
 class ExportMissionPatrolCombinedTest {
@@ -20,10 +20,10 @@ class ExportMissionPatrolCombinedTest {
     @Autowired
     private lateinit var exportMissionPatrolCombined: ExportMissionPatrolCombined
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionPatrolSingle: ExportMissionPatrolSingle
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMission: GetMission
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolMultipleZippedTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolMultipleZippedTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [ExportMissionPatrolMultipleZipped::class, ZipFiles::class])
 class ExportMissionPatrolMultipleZippedTest {
@@ -22,10 +22,10 @@ class ExportMissionPatrolMultipleZippedTest {
     @Autowired
     private lateinit var exportMissionPatrolMultipleZipped: ExportMissionPatrolMultipleZipped
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionPatrolSingle: ExportMissionPatrolSingle
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMission: GetMission
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingleTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingleTest.kt
@@ -22,7 +22,7 @@ import org.mockito.Mockito.reset
 import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(
     classes = [
@@ -40,22 +40,22 @@ class ExportMissionPatrolSingleTest {
     @Autowired
     private lateinit var exportMissionRapportPatrouille: ExportMissionPatrolSingle
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMissionGeneralInfoByMissionId: GetMissionGeneralInfoByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var agentsCrewByMissionId: GetAgentsCrewByMissionId
 
-    @MockBean
+    @MockitoBean
     private lateinit var getMission: GetMission
 
-    @MockBean
+    @MockitoBean
     private lateinit var navActionStatus: INavActionStatusRepository
 
-    @MockBean
+    @MockitoBean
     private lateinit var formatActionsForTimeline: FormatActionsForTimeline
 
-    @MockBean
+    @MockitoBean
     private lateinit var getServiceById: GetServiceById
 
     @BeforeEach

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionReportsTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionReportsTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [ExportMissionReports::class])
 class ExportMissionReportsTest {
@@ -19,22 +19,22 @@ class ExportMissionReportsTest {
     @Autowired
     private lateinit var exportMissionReports: ExportMissionReports
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionPatrolSingle: ExportMissionPatrolSingle
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionPatrolCombined: ExportMissionPatrolCombined
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionPatrolMultipleZipped: ExportMissionPatrolMultipleZipped
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionAEMSingle: ExportMissionAEMSingle
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionAEMCombined: ExportMissionAEMCombined
 
-    @MockBean
+    @MockitoBean
     private lateinit var exportMissionAEMMultipleZipped: ExportMissionAEMMultipleZipped
 
     @BeforeEach

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/status/GetStatusForActionTests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/status/GetStatusForActionTests.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import java.time.Instant
@@ -36,7 +36,7 @@ class GetStatusForActionTests {
 
     private var missionId: Int = 1
 
-    @MockBean
+    @MockitoBean
     private lateinit var statusActionsRepository: INavActionStatusRepository
 
     @Autowired
@@ -44,9 +44,9 @@ class GetStatusForActionTests {
 
     @Test
     fun `execute Should return Unknown when action is empty list for a mission`() {
-        given(this.statusActionsRepository.findAllByMissionId(missionId = 1)).willReturn(listOf());
-        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = null);
-        assertThat(statusForAction).isEqualTo(ActionStatusType.UNKNOWN);
+        given(this.statusActionsRepository.findAllByMissionId(missionId = 1)).willReturn(listOf())
+        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = null)
+        assertThat(statusForAction).isEqualTo(ActionStatusType.UNKNOWN)
     }
 
     @Test
@@ -63,8 +63,8 @@ class GetStatusForActionTests {
             ActionStatusModel.fromActionStatusEntity(
                 it
             )
-        });
-        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = startDatetime);
-        assertThat(statusForAction).isEqualTo(ActionStatusType.UNAVAILABLE);
+        })
+        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = startDatetime)
+        assertThat(statusForAction).isEqualTo(ActionStatusType.UNAVAILABLE)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetEnvMissionById2Test.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetEnvMissionById2Test.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.Instant
 
 @SpringBootTest(classes = [GetEnvMissionById2::class])
@@ -19,7 +19,7 @@ class GetEnvMissionById2Test {
     @Autowired
     private lateinit var getEnvMissionById2: GetEnvMissionById2
 
-    @MockBean
+    @MockitoBean
     private lateinit var monitorEnvApiRepo: IEnvMissionRepository
 
     @Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/ApiAdminControllerITest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/ApiAdminControllerITest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.jwt.JwtDecoder
@@ -19,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 
@@ -30,26 +30,26 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 class ApiAdminControllerITest {
 
     @Autowired
-    private lateinit var api: MockMvc;
+    private lateinit var api: MockMvc
 
-    @MockBean
-    private lateinit var jwtDecoder: JwtDecoder;
+    @MockitoBean
+    private lateinit var jwtDecoder: JwtDecoder
 
-    @MockBean
-    private lateinit var jwtEncoder: JwtEncoder;
+    @MockitoBean
+    private lateinit var jwtEncoder: JwtEncoder
 
-    @MockBean
-    private lateinit var userRepository: IUserRepository;
+    @MockitoBean
+    private lateinit var userRepository: IUserRepository
 
     @Autowired
-    private lateinit var tokenService: TokenService;
+    private lateinit var tokenService: TokenService
 
     @Test
     fun `Should return 401 if the user has not JWT token`() {
         val t = api.perform(
             get("/api/v1/admin/test")
                 .header("X-Xsrf-Token", "b321f985-a7dd-47ea-a1e0-d05d8791dbd8")
-        );
+        )
         t.andExpect(status().isUnauthorized)
     }
 
@@ -59,7 +59,7 @@ class ApiAdminControllerITest {
             get("/api/v1/admin/test")
                 .header("X-Xsrf-Token", "b321f985-a7dd-47ea-a1e0-d05d8791dbd8")
                 .with(jwt().authorities(SimpleGrantedAuthority("ROLE_USER")))
-        );
+        )
         t.andExpect(status().isForbidden)
     }
 
@@ -69,7 +69,7 @@ class ApiAdminControllerITest {
             get("/api/v1/admin/test")
                 .header("X-Xsrf-Token", "b321f985-a7dd-47ea-a1e0-d05d8791dbd8")
                 .with(jwt().authorities(SimpleGrantedAuthority("ROLE_ADMIN")))
-        );
+        )
         t.andExpect(status().isOk)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAAgentServiceRepositoryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAAgentServiceRepositoryTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 
@@ -18,33 +18,33 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 @SpringBootTest(classes = [JPAAgentServiceRepository::class])
 class JPAAgentServiceRepositoryTest {
 
-    @MockBean
-    private lateinit var dbServiceRepository: IDBAgentServiceRepository;
+    @MockitoBean
+    private lateinit var dbServiceRepository: IDBAgentServiceRepository
 
 
     private val agentServices: List<AgentServiceModel> = listOf(
         AgentServiceModel(
             id = 1,
-            agent = AgentModel(id=1, firstName = "", lastName=""),
+            agent = AgentModel(id = 1, firstName = "", lastName = ""),
             serviceId = 1,
-            role = AgentRoleModel(id=1, title = "")
-        ),  AgentServiceModel(
+            role = AgentRoleModel(id = 1, title = "")
+        ), AgentServiceModel(
             id = 2,
-            agent = AgentModel(id=1, firstName = "", lastName=""),
+            agent = AgentModel(id = 1, firstName = "", lastName = ""),
             serviceId = 1,
-            role = AgentRoleModel(id=1, title = "")
+            role = AgentRoleModel(id = 1, title = "")
         )
-    );
+    )
 
 
     @Test
     fun `execute should retrieve agents  service by service id`() {
-        Mockito.`when`(dbServiceRepository.findByServiceId(1)).thenReturn(agentServices);
+        Mockito.`when`(dbServiceRepository.findByServiceId(1)).thenReturn(agentServices)
         var jpaAgentServiceRepo = JPAAgentServiceRepository(dbServiceRepository)
         val responses = jpaAgentServiceRepo.findByServiceId(1)
-        assertThat(responses).isNotNull();
+        assertThat(responses).isNotNull()
 
-        assertThat(responses.size).isEqualTo(2);
-        assertThat(responses.map { agent -> agent.id }).containsAll(listOf(1, 2));
+        assertThat(responses.size).isEqualTo(2)
+        assertThat(responses.map { agent -> agent.id }).containsAll(listOf(1, 2))
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAServiceRepositoryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAServiceRepositoryTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 @ExtendWith(SpringExtension::class)
@@ -16,8 +16,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 class JPAServiceRepositoryTest {
 
 
-    @MockBean
-    private lateinit var dbServiceRepository: IDBServiceRepository;
+    @MockitoBean
+    private lateinit var dbServiceRepository: IDBServiceRepository
 
 
     private val serviceModels: List<ServiceModel> = listOf(
@@ -35,29 +35,29 @@ class JPAServiceRepositoryTest {
             name = "thirdService",
             controlUnits = listOf(4, 5)
         )
-    );
+    )
 
 
     @Test
     fun `execute should retrieve serviceModel with control units list`() {
-        Mockito.`when`(dbServiceRepository.findAll()).thenReturn(serviceModels);
+        Mockito.`when`(dbServiceRepository.findAll()).thenReturn(serviceModels)
         val jpaServiceRepo = JPAServiceRepository(dbServiceRepository)
         val response = jpaServiceRepo.findByControlUnitId(listOf(3))
-        assertThat(response).isNotNull();
+        assertThat(response).isNotNull()
 
-        assertThat(response.size).isEqualTo(2);
-        assertThat(response.map { service -> service.id }).containsAll(listOf(3, 4));
+        assertThat(response.size).isEqualTo(2)
+        assertThat(response.map { service -> service.id }).containsAll(listOf(3, 4))
     }
 
     @Test
     fun `execute should retrieve serviceModel with control units list when receiving several controlUnits in input`() {
-        Mockito.`when`(dbServiceRepository.findAll()).thenReturn(serviceModels);
+        Mockito.`when`(dbServiceRepository.findAll()).thenReturn(serviceModels)
         val jpaServiceRepo = JPAServiceRepository(dbServiceRepository)
         val response = jpaServiceRepo.findByControlUnitId(listOf(3, 348))
-        assertThat(response).isNotNull();
+        assertThat(response).isNotNull()
 
-        assertThat(response.size).isEqualTo(2);
-        assertThat(response.map { service -> service.id }).containsAll(listOf(3, 4));
+        assertThat(response.size).isEqualTo(2)
+        assertThat(response.map { service -> service.id }).containsAll(listOf(3, 4))
     }
 
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/crew/action/JPAMissionActionRepositoryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/crew/action/JPAMissionActionRepositoryTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mockito
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.time.Instant
 import java.util.*
@@ -18,8 +18,8 @@ import java.util.*
 @SpringBootTest(classes = [JPAMissionActionRepository::class])
 class JPAMissionActionRepositoryTest {
 
-    @MockBean
-    private lateinit var dbServiceRepository: IDBMissionActionRepository;
+    @MockitoBean
+    private lateinit var dbServiceRepository: IDBMissionActionRepository
 
     final val id1 = UUID.randomUUID()
     final val id2 = UUID.randomUUID()
@@ -42,25 +42,25 @@ class JPAMissionActionRepositoryTest {
             actionType = ActionType.SURVEILLANCE,
             startDateTimeUtc = Instant.parse("2024-04-17T07:00:00Z"),
         )
-    );
+    )
 
     @Test
     fun `execute should retrieve action by mission id`() {
-        Mockito.`when`(dbServiceRepository.findAllByMissionId(761)).thenReturn(missionActions);
+        Mockito.`when`(dbServiceRepository.findAllByMissionId(761)).thenReturn(missionActions)
         val jPAMissionActionRepository = JPAMissionActionRepository(dbServiceRepository)
         val responses = jPAMissionActionRepository.findByMissionId(missionId = 761)
-        assertThat(responses).isNotNull();
-        assertThat(responses.size).isEqualTo(3);
-        assertThat(responses.map { action -> action.id }).containsAll(listOf(id1, id2));
+        assertThat(responses).isNotNull()
+        assertThat(responses.size).isEqualTo(3)
+        assertThat(responses.map { action -> action.id }).containsAll(listOf(id1, id2))
     }
 
     @Test
     fun `execute should retrieve action by id`() {
-        Mockito.`when`(dbServiceRepository.findById(id1)).thenReturn(Optional.of(missionActions.get(0)));
+        Mockito.`when`(dbServiceRepository.findById(id1)).thenReturn(Optional.of(missionActions.get(0)))
         val jPAMissionActionRepository = JPAMissionActionRepository(dbServiceRepository)
         val response = jPAMissionActionRepository.findById(id = id1).orElse(null)
-        assertThat(response).isNotNull();
-        assertThat(response?.id).isEqualTo(id1);
+        assertThat(response).isNotNull()
+        assertThat(response?.id).isEqualTo(id1)
     }
 
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/monitorenv/APIEnvMissionRepositoryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/monitorenv/APIEnvMissionRepositoryTest.kt
@@ -20,7 +20,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.net.URI
 import java.net.http.HttpClient
@@ -35,7 +35,7 @@ import java.util.*
 @SpringBootTest(classes = [APIEnvMissionRepository::class])
 class APIEnvMissionRepositoryTest {
 
-    val host = "https://monitorenv.din.developpement-durable.gouv.fr";
+    val host = "https://monitorenv.din.developpement-durable.gouv.fr"
 
     val mission = MissionDataOutput(
         id = 761,
@@ -50,18 +50,18 @@ class APIEnvMissionRepositoryTest {
         observationsByUnit = "my observationsByUnit"
     )
 
-    @MockBean
-    private lateinit var objectMapper: ObjectMapper;
+    @MockitoBean
+    private lateinit var objectMapper: ObjectMapper
 
     @Mock
     private var httpResponse = mock<HttpResponse<String>>()
 
 
-    @MockBean
-    private lateinit var httpClientFactory: HttpClientFactory;
+    @MockitoBean
+    private lateinit var httpClientFactory: HttpClientFactory
 
     @Mock
-    private var httpClient: HttpClient = mock(HttpClient::class.java);
+    private var httpClient: HttpClient = mock(HttpClient::class.java)
 
 
     @Nested
@@ -69,15 +69,15 @@ class APIEnvMissionRepositoryTest {
         @Test
         fun `execute should update mission env with patch and observationsByUnit`() {
 
-            Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient);
-            Mockito.`when`(httpResponse.body()).thenReturn(getMissionString());
+            Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient)
+            Mockito.`when`(httpResponse.body()).thenReturn(getMissionString())
             Mockito.`when`(
                 httpClient.send(
                     Mockito.any(HttpRequest::class.java),
                     Mockito.any<HttpResponse.BodyHandler<String>>()
                 )
             )
-                .thenReturn(httpResponse);
+                .thenReturn(httpResponse)
             val envRepo = APIEnvMissionRepository(mapper = objectMapper, clientFactory = httpClientFactory)
             envRepo.patchMission(
                 missionId = 761,
@@ -97,7 +97,7 @@ class APIEnvMissionRepositoryTest {
 
         private fun getMissionString(): String {
             val gson: Gson = GsonSerializer().create()
-            return gson.toJson(mission);
+            return gson.toJson(mission)
         }
     }
 
@@ -113,21 +113,21 @@ class APIEnvMissionRepositoryTest {
 
         private fun getActionString(): String {
             val gson: Gson = GsonSerializer().create()
-            return gson.toJson(action);
+            return gson.toJson(action)
         }
 
         @Test
         fun `execute should update action env with patch and observationsByUnit`() {
 
-            Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient);
-            Mockito.`when`(httpResponse.body()).thenReturn(getActionString());
+            Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient)
+            Mockito.`when`(httpResponse.body()).thenReturn(getActionString())
             Mockito.`when`(
                 httpClient.send(
                     Mockito.any(HttpRequest::class.java),
                     Mockito.any<HttpResponse.BodyHandler<String>>()
                 )
             )
-                .thenReturn(httpResponse);
+                .thenReturn(httpResponse)
             val envRepo = APIEnvMissionRepository(mapper = objectMapper, clientFactory = httpClientFactory)
             envRepo.patchAction(
                 actionId = action.id.toString(),

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitRepositoryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitRepositoryTest.kt
@@ -13,7 +13,7 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.net.URI
 import java.net.http.HttpClient
@@ -32,34 +32,34 @@ class APIEnvControlUnitRepositoryTest {
         resources = listOf()
     )
 
-    val host = "https://monitorenv.din.developpement-durable.gouv.fr";
+    val host = "https://monitorenv.din.developpement-durable.gouv.fr"
 
-    @MockBean
-    private lateinit var objectMapper: ObjectMapper;
+    @MockitoBean
+    private lateinit var objectMapper: ObjectMapper
 
     @Mock
     private var httpResponse = Mockito.mock<HttpResponse<String>>()
 
 
-    @MockBean
-    private lateinit var httpClientFactory: HttpClientFactory;
+    @MockitoBean
+    private lateinit var httpClientFactory: HttpClientFactory
 
     @Mock
-    private var httpClient: HttpClient = Mockito.mock(HttpClient::class.java);
+    private var httpClient: HttpClient = Mockito.mock(HttpClient::class.java)
 
 
     @Test
     fun `execute should fet controlUnits from monitorenv`() {
 
-        Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient);
-        Mockito.`when`(httpResponse.body()).thenReturn(getMissionString());
+        Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient)
+        Mockito.`when`(httpResponse.body()).thenReturn(getMissionString())
         Mockito.`when`(
             httpClient.send(
                 Mockito.any(HttpRequest::class.java),
                 Mockito.any<HttpResponse.BodyHandler<String>>()
             )
         )
-            .thenReturn(httpResponse);
+            .thenReturn(httpResponse)
         val envRepo = APIEnvControlUnitRepository(mapper = objectMapper, clientFactory = httpClientFactory)
         envRepo.findAll()
         verify(httpClient).send(
@@ -74,6 +74,6 @@ class APIEnvControlUnitRepositoryTest {
 
     private fun getMissionString(): String {
         val gson: Gson = GsonSerializer().create()
-        return gson.toJson(listOf(legacyControlUnit));
+        return gson.toJson(listOf(legacyControlUnit))
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/monitorenv/v2/APIEnvMissionRepositoryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/monitorenv/v2/APIEnvMissionRepositoryTest.kt
@@ -17,7 +17,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.net.URI
 import java.net.http.HttpClient
@@ -31,7 +31,7 @@ import java.time.ZonedDateTime
 @SpringBootTest(classes = [APIEnvMissionRepositoryV2::class])
 class APIEnvMissionRepositoryTest {
 
-    val host = "https://monitorenv.din.developpement-durable.gouv.fr";
+    val host = "https://monitorenv.din.developpement-durable.gouv.fr"
 
     val mission = MissionDataOutput(
         id = 761,
@@ -46,32 +46,32 @@ class APIEnvMissionRepositoryTest {
         observationsByUnit = "my observationsByUnit"
     )
 
-    @MockBean
-    private lateinit var objectMapper: ObjectMapper;
+    @MockitoBean
+    private lateinit var objectMapper: ObjectMapper
 
     @Mock
     private var httpResponse = mock<HttpResponse<String>>()
 
 
-    @MockBean
-    private lateinit var httpClientFactory: HttpClientFactory;
+    @MockitoBean
+    private lateinit var httpClientFactory: HttpClientFactory
 
     @Mock
-    private var httpClient: HttpClient = mock(HttpClient::class.java);
+    private var httpClient: HttpClient = mock(HttpClient::class.java)
 
 
     @Test
     fun `execute should create mission env`() {
 
-        Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient);
-        Mockito.`when`(httpResponse.body()).thenReturn(getMissionString());
+        Mockito.`when`(httpClientFactory.create()).thenReturn(httpClient)
+        Mockito.`when`(httpResponse.body()).thenReturn(getMissionString())
         Mockito.`when`(
             httpClient.send(
                 Mockito.any(HttpRequest::class.java),
                 Mockito.any<HttpResponse.BodyHandler<String>>()
             )
         )
-            .thenReturn(httpResponse);
+            .thenReturn(httpResponse)
         val envRepo = APIEnvMissionRepositoryV2(mapper = objectMapper, clientFactory = httpClientFactory)
         val mission = MissionEnv(
             missionTypes = listOf(MissionTypeEnum.SEA),
@@ -87,8 +87,8 @@ class APIEnvMissionRepositoryTest {
         verify(httpClient).send(
             argThat { request ->
                 request.uri() == URI.create("$host/api/v1/missions") &&
-                    request.method() == "POST" &&
-                    request.headers().firstValue("Content-Type").orElse("") == "application/json"
+                        request.method() == "POST" &&
+                        request.headers().firstValue("Content-Type").orElse("") == "application/json"
             },
             Mockito.any<HttpResponse.BodyHandler<String>>()
         )
@@ -98,7 +98,7 @@ class APIEnvMissionRepositoryTest {
 
     private fun getMissionString(): String {
         val gson: Gson = GsonSerializer().create()
-        return gson.toJson(mission);
+        return gson.toJson(mission)
     }
 }
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/utils/ExportZipTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/utils/ExportZipTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.io.File
 import java.io.FileInputStream
 import java.util.zip.ZipInputStream
@@ -18,13 +18,14 @@ class ExportZipTest {
     @Autowired
     private lateinit var fileUtils: FileUtils
 
-    @MockBean
+    @MockitoBean
     private lateinit var fillAEMExcelRow: FillAEMExcelRow
 
     @Test
     fun `should zip a list of files`() {
 
-        val filesToZip = listOf(File("file1.txt").apply { writeText("Hello, World!") },
+        val filesToZip = listOf(
+            File("file1.txt").apply { writeText("Hello, World!") },
             File("file2.txt").apply { writeText("Kotlin ZIP Test") })
 
         val zipFile = File("test_output.zip")


### PR DESCRIPTION
La PR est grosse mais c'est bidon : j'ai récemment updaté à spring-boot 3.4 et il fallait remplacer les directives `@MockBean` par `@MockitoBean` dans les tests