### PR TITLE
fix(RapportPatrouille): use sum of statuses to compute mission duration

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingle.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingle.kt
@@ -87,14 +87,9 @@ class ExportMissionPatrolSingle(
                 .map { it.toActionStatusEntity() }
 
             val durations = mapStatusDurations.execute(mission, statuses, DurationUnit.HOURS)
-            val missionDuration = computeDurations.convertFromSeconds(
-                computeDurations.durationInSeconds(
-                    mission.startDateTimeUtc,
-                    mission.endDateTimeUtc,
-
-                    ) ?: 0,
-                DurationUnit.HOURS
-            )
+            val missionDuration = durations.values
+                .flatMap { it.values }
+                .sum()
 
             val nbOfDaysAtSea = getNbOfDaysAtSeaFromNavigationStatus.execute(
                 missionStartDateTime = mission.startDateTimeUtc,


### PR DESCRIPTION
Revisite du calcul de durée de mission comme validé dans la sync dev
On utilise maintenant la somme des durées des status plutot que les dates de début/fin de mission