### PR TITLE
fix: fix flickering observationsByUnit

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/PatchEnvMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/PatchEnvMission.kt
@@ -14,6 +14,7 @@ class PatchEnvMission(private val envRepository: IEnvMissionRepository) {
     @Caching(
         evict = [
             CacheEvict(value = ["envMission"], key = "#input.missionId"),
+            CacheEvict(value = ["envMission2"], key = "#input.missionId"),
         ]
     )
     fun execute(

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/PatchEnvAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/PatchEnvAction.kt
@@ -14,6 +14,8 @@ class PatchEnvAction(private val envRepository: IEnvMissionRepository) {
     @Caching(
         evict = [
             CacheEvict(value = ["envMission"], key = "#input.missionId"),
+            CacheEvict(value = ["envMission2"], key = "#input.missionId"),
+            CacheEvict(value = ["envActionList"], key = "#input.missionId"),
         ]
     )
     fun execute(

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/PatchFishAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/PatchFishAction.kt
@@ -14,6 +14,7 @@ class PatchFishAction(private val fishRepository: IFishActionRepository) {
     @Caching(
         evict = [
             CacheEvict(value = ["fishActions"], key = "#input.missionId"),
+            CacheEvict(value = ["fishActionList"], key = "#input.missionId"),
         ]
     )
     fun execute(

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/cache/CaffeineConfiguration.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/cache/CaffeineConfiguration.kt
@@ -30,19 +30,19 @@ class CaffeineConfiguration {
     fun cacheManager(ticker: Ticker): CacheManager? {
 
         // long term caches for very static data
-        val natinfsCache = builCache(natinfs, ticker, TimeUnit.DAYS, 7)
-        val controlPlansCache = builCache(controlPlans, ticker, TimeUnit.DAYS, 7)
+        val natinfsCache = buildCache(natinfs, ticker, TimeUnit.DAYS, 7)
+        val controlPlansCache = buildCache(controlPlans, ticker, TimeUnit.DAYS, 7)
 
         // short term caches for Missions and Actions
-        val envMissionsCache = builCache(envMissions, ticker, TimeUnit.MINUTES, 5)
-        val envMissionCache = builCache(envMission, ticker, TimeUnit.MINUTES, 5)
-        val fishActionsCache = builCache(fishActions, ticker, TimeUnit.MINUTES, 5)
+        val envMissionsCache = buildCache(envMissions, ticker, TimeUnit.MINUTES, 5)
+        val envMissionCache = buildCache(envMission, ticker, TimeUnit.MINUTES, 5)
+        val fishActionsCache = buildCache(fishActions, ticker, TimeUnit.MINUTES, 5)
 
 
         // short term caches for Missions and Actions
-        val envMissionCache2 = builCache(envMission2, ticker, TimeUnit.MINUTES, 5)
-        val envActionListCache = builCache(envActionList, ticker, TimeUnit.MINUTES, 5)
-        val fishActionListCache = builCache(fishActionList, ticker, TimeUnit.MINUTES, 5)
+        val envMissionCache2 = buildCache(envMission2, ticker, TimeUnit.MINUTES, 5)
+        val envActionListCache = buildCache(envActionList, ticker, TimeUnit.MINUTES, 5)
+        val fishActionListCache = buildCache(fishActionList, ticker, TimeUnit.MINUTES, 5)
 
 
         val manager = SimpleCacheManager()
@@ -65,7 +65,7 @@ class CaffeineConfiguration {
         return manager
     }
 
-    private fun builCache(name: String, ticker: Ticker, timeUnit: TimeUnit, durationInUnit: Int): CaffeineCache {
+    private fun buildCache(name: String, ticker: Ticker, timeUnit: TimeUnit, durationInUnit: Int): CaffeineCache {
         return CaffeineCache(
             name,
             Caffeine.newBuilder()

--- a/frontend/src/features/pam/mission/hooks/use-mission-by-id.tsx
+++ b/frontend/src/features/pam/mission/hooks/use-mission-by-id.tsx
@@ -21,6 +21,7 @@ export const GET_MISSION_BY_ID = gql`
         nbrOfRecognizedVessel
         serviceId
       }
+      observationsByUnit
       actions {
         id
         type

--- a/frontend/src/features/pam/mission/hooks/use-mission-timeline.tsx
+++ b/frontend/src/features/pam/mission/hooks/use-mission-timeline.tsx
@@ -8,6 +8,7 @@ export const GET_MISSION_TIMELINE = gql`
       startDateTimeUtc
       endDateTimeUtc
       status
+      observationsByUnit
       completenessForStats {
         status
         sources


### PR DESCRIPTION
Je pense que j'ai trouvé pour le bug des observationsByUnit qui sautent, c'était pas une histoire de cache parce qu'il était déjà evict lors du PatchEnvMission. J'en ai profité pour evict le cache v2 aussi.
C'était plutot un probleme que le field était pas redemandé dans certaines query graphql qui partageaient la meme key
