### PR TITLE
fix(mutations): add mutation scope to run paused mutations in serial …

### DIFF
--- a/frontend/src/v2/features/common/services/use-create-mission-action.tsx
+++ b/frontend/src/v2/features/common/services/use-create-mission-action.tsx
@@ -16,6 +16,9 @@ const useCreateMissionActionMutation = (
     mutationFn: createAction,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: missionsKeys.byId(missionId) })
+    },
+    scope: {
+      id: 'create-action'
     }
   })
   return mutation

--- a/frontend/src/v2/features/common/services/use-delete-mission-action.tsx
+++ b/frontend/src/v2/features/common/services/use-delete-mission-action.tsx
@@ -13,6 +13,9 @@ const useDeleteActionMutation = (missionId: number): UseMutationResult<void, Err
     mutationFn: deleteAction,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: missionsKeys.byId(missionId) })
+    },
+    scope: {
+      id: 'delete-action'
     }
   })
   return mutation

--- a/frontend/src/v2/features/common/services/use-update-generalInfo.tsx
+++ b/frontend/src/v2/features/common/services/use-update-generalInfo.tsx
@@ -21,6 +21,9 @@ const useUpdateGeneralInfoMutation = (
     onError: error => {
       console.error(error)
       Sentry.captureException(error)
+    },
+    scope: {
+      id: `update-general-info-${missionId}`
     }
   })
 }

--- a/frontend/src/v2/features/common/services/use-update-mission-action.tsx
+++ b/frontend/src/v2/features/common/services/use-update-mission-action.tsx
@@ -17,6 +17,9 @@ const useUpdateMissionActionMutation = (
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: actionsKeys.byId(actionId) })
       queryClient.invalidateQueries({ queryKey: missionsKeys.byId(missionId) })
+    },
+    scope: {
+      id: `update-action-${actionId}`
     }
   })
   return mutation

--- a/frontend/src/v2/features/ulam/services/use-create-mission.tsx
+++ b/frontend/src/v2/features/ulam/services/use-create-mission.tsx
@@ -19,6 +19,9 @@ const useCreateMissionMutation = (): UseMutationResult<Mission, Error, MissionGe
     onError: error => {
       console.error(error)
       Sentry.captureException(error)
+    },
+    scope: {
+      id: 'create-mission'
     }
   })
 }


### PR DESCRIPTION
…instead of parallel

C"est à propos du offline mais je voulais séparer ça afin de montrer le concept en isolation.
La doc ici: https://tanstack.com/query/latest/docs/framework/react/guides/mutations#mutation-scopes


`Per default, all mutations run in parallel - even if you invoke .mutate() of the same mutation multiple times. Mutations can be given a scope with an id to avoid that. All mutations with the same scope.id will run in serial, which means when they are triggered, they will start in isPaused: true state if there is already a mutation for that scope in progress. They will be put into a queue and will automatically resume once their time in the queue has come.`

Ca évitera des cas foireux où des mutations sur les mêmes objets soient pas exécutées dans le bon ordre. Ce fameux cas de champs qui disparait qui nous a pourri sur la v1
