### PR TITLE
feat(Online): improve online hook and toggle component

### DIFF
--- a/frontend/src/v2/features/common/components/elements/__tests__/online-toggle.test.tsx
+++ b/frontend/src/v2/features/common/components/elements/__tests__/online-toggle.test.tsx
@@ -15,7 +15,9 @@ describe('OnlineToggle', () => {
     vi.mocked(useOnlineManager).mockReturnValue({
       isOnline: true,
       isOffline: false,
-      setOnline: vi.fn()
+      hasNetwork: true,
+      manualOffline: false,
+      toggleOnline: vi.fn()
     })
 
     const { getByText, getByRole } = render(<OnlineToggle />)
@@ -40,7 +42,9 @@ describe('OnlineToggle', () => {
     vi.mocked(useOnlineManager).mockReturnValue({
       isOnline: false,
       isOffline: true,
-      setOnline: vi.fn()
+      hasNetwork: true,
+      manualOffline: false,
+      toggleOnline: vi.fn()
     })
 
     const { getByText, getByRole } = render(<OnlineToggle />)
@@ -60,15 +64,17 @@ describe('OnlineToggle', () => {
     expect(toggle).not.toBeChecked()
   })
 
-  it('calls setOnline when toggle is clicked', () => {
-    // Create a mock setOnline function
+  it('calls toggleOnline when toggle is clicked', () => {
+    // Create a mock toggleOnline function
     const mockSetOnline = vi.fn()
 
     // Mock the hook to return a controllable state
     vi.mocked(useOnlineManager).mockReturnValue({
       isOnline: true,
       isOffline: false,
-      setOnline: mockSetOnline
+      hasNetwork: true,
+      manualOffline: false,
+      toggleOnline: mockSetOnline
     })
 
     const { getByRole } = render(<OnlineToggle />)
@@ -77,7 +83,62 @@ describe('OnlineToggle', () => {
     const toggle = getByRole('switch')
     fireEvent.click(toggle)
 
-    // Verify setOnline was called with the opposite of current state
+    // Verify toggleOnline was called with the opposite of current state
     expect(mockSetOnline).toHaveBeenCalledWith(false)
+  })
+
+  it('shows correct title when toggle is disabled due to chosen offline mode', () => {
+    // Mock the hook to simulate disabled toggle
+    const mockToggleOnline = vi.fn()
+    vi.mocked(useOnlineManager).mockReturnValue({
+      isOnline: false,
+      isOffline: true,
+      hasNetwork: true,
+      manualOffline: false,
+      toggleOnline: mockToggleOnline
+    })
+
+    const { getByRole } = render(<OnlineToggle />)
+
+    // Get the input element (the toggle), not disabled
+    const toggleInput = getByRole('switch') as HTMLInputElement
+    expect(toggleInput).not.toBeDisabled()
+
+    // Access the parent label and check the title attribute
+    const label = toggleInput.closest('label')
+    expect(label).toHaveAttribute(
+      'title',
+      'Vous êtes hors-ligne mais une connection est détectée, vous pouvez tenter de revenir en ligne.'
+    )
+
+    // Try clicking the disabled toggle - it should trigger a change
+    fireEvent.click(toggleInput)
+    expect(mockToggleOnline).toHaveBeenCalled()
+  })
+
+  it('shows correct title when toggle is disabled due to missing network', () => {
+    // Mock the hook to simulate disabled toggle
+    const mockToggleOnline = vi.fn()
+    vi.mocked(useOnlineManager).mockReturnValue({
+      isOnline: false,
+      isOffline: true,
+      hasNetwork: false,
+      manualOffline: false,
+      toggleOnline: mockToggleOnline
+    })
+
+    const { getByRole } = render(<OnlineToggle />)
+
+    // Get the input element (the toggle), disabled
+    const toggleInput = getByRole('switch') as HTMLInputElement
+    expect(toggleInput).toBeDisabled()
+
+    // Access the parent label and check the title attribute
+    const label = toggleInput.closest('label')
+    expect(label).toHaveAttribute('title', 'Nous ne pouvez pas passer en ligne, connection non détectée.')
+
+    // Try clicking the disabled toggle, it should not do anything
+    fireEvent.click(toggleInput)
+    expect(mockToggleOnline).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/v2/features/common/components/elements/online-toggle.tsx
+++ b/frontend/src/v2/features/common/components/elements/online-toggle.tsx
@@ -44,17 +44,27 @@ const StyledToggle = styled(Toggle)`
       margin-top: 4px;
     }
   }
+
+  // disabled state 🔒
+  .rs-toggle-disabled {
+    .rs-toggle-presentation {
+      background-color: ${THEME.color.slateGray}!important;
+    }
+    .rs-toggle-input {
+      cursor: not-allowed !important;
+    }
+  }
 `
 
 export const OnlineToggle: FC<OfflineToggleProps> = () => {
-  const { isOnline, setOnline } = useOnlineManager()
+  const { isOnline, hasNetwork, toggleOnline } = useOnlineManager()
 
   return (
     <Stack direction={'row'} alignItems={'center'} justifyContent={'center'} spacing={'0.5rem'}>
       <Stack.Item>
         <Text
           as={'h3'}
-          color={isOnline ? THEME.color.lightGray : THEME.color.maximumRed}
+          color={isOnline ? THEME.color.lightGray : hasNetwork ? THEME.color.maximumRed : THEME.color.slateGray}
           weight={isOnline ? 'normal' : 'bold'}
         >
           Hors ligne
@@ -65,9 +75,17 @@ export const OnlineToggle: FC<OfflineToggleProps> = () => {
           label={''}
           name="online-toggle"
           checked={isOnline}
+          disabled={!hasNetwork}
+          title={
+            !hasNetwork
+              ? 'Nous ne pouvez pas passer en ligne, connection non détectée.'
+              : !isOnline && hasNetwork
+                ? 'Vous êtes hors-ligne mais une connection est détectée, vous pouvez tenter de revenir en ligne.'
+                : ''
+          }
           checkedChildren={<Icon.Check color={THEME.color.white} size={14} />}
           unCheckedChildren={<Icon.Offline color={THEME.color.white} size={14} />}
-          onChange={(isChecked: boolean) => setOnline(isChecked)}
+          onChange={(isChecked: boolean) => toggleOnline(isChecked)}
         />
       </Stack.Item>
       <Stack.Item>

--- a/frontend/src/v2/features/common/components/ui/__tests__/__snapshots__/mission-page-footer.test.tsx.snap
+++ b/frontend/src/v2/features/common/components/ui/__tests__/__snapshots__/mission-page-footer.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`MissionPageFooter > should match the snapshot 1`] = `
                 class="rs-stack-item"
               >
                 <div
-                  class="sc-gDVcuj geGcsH Element-Field Field-Toggle sc-irwjCN kaHqrQ"
+                  class="sc-gDVcuj geGcsH Element-Field Field-Toggle sc-irwjCN lkzbPC"
                 >
                   <label
                     class="sc-kmqAS fyCASS Element-Label"
@@ -99,6 +99,7 @@ exports[`MissionPageFooter > should match the snapshot 1`] = `
                   />
                   <label
                     class="sc-fsONnU kaFjBT rs-toggle rs-toggle-checked"
+                    title=""
                   >
                     <input
                       aria-checked="true"
@@ -282,7 +283,7 @@ exports[`MissionPageFooter > should match the snapshot 1`] = `
               class="rs-stack-item"
             >
               <div
-                class="sc-gDVcuj geGcsH Element-Field Field-Toggle sc-irwjCN kaHqrQ"
+                class="sc-gDVcuj geGcsH Element-Field Field-Toggle sc-irwjCN lkzbPC"
               >
                 <label
                   class="sc-kmqAS fyCASS Element-Label"
@@ -290,6 +291,7 @@ exports[`MissionPageFooter > should match the snapshot 1`] = `
                 />
                 <label
                   class="sc-fsONnU kaFjBT rs-toggle rs-toggle-checked"
+                  title=""
                 >
                   <input
                     aria-checked="true"

--- a/frontend/src/v2/features/common/hooks/__tests__/use-online-manager.test.tsx
+++ b/frontend/src/v2/features/common/hooks/__tests__/use-online-manager.test.tsx
@@ -1,22 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useOnlineManager } from '../use-online-manager.tsx'
 import { onlineManager } from '@tanstack/react-query'
-import { renderHook, waitFor } from '../../../../../test-utils.tsx'
+import { renderHook, act, waitFor } from '../../../../../test-utils.tsx'
 
 describe('useOnlineManager', () => {
-  let isOnline = true // Default state
+  let isOnline = true
 
   beforeEach(() => {
+    // initial TanStack Query state
     vi.spyOn(onlineManager, 'isOnline').mockReturnValue(isOnline)
+    // subscribe should immediately callback with current isOnline
     vi.spyOn(onlineManager, 'subscribe').mockImplementation(cb => {
-      console.log('Mocked subscribe called with:', isOnline)
-      cb(isOnline) // Initial callback
-      return () => {} // Mock unsubscribe
+      cb(isOnline)
+      return () => {}
     })
-
-    vi.spyOn(onlineManager, 'setOnline').mockImplementation(value => {
-      console.log(`setOnline called with ${value}`)
-      isOnline = value
+    // track when we push state back into TanStack Query
+    vi.spyOn(onlineManager, 'setOnline').mockImplementation(val => {
+      isOnline = val
     })
   })
 
@@ -24,25 +24,66 @@ describe('useOnlineManager', () => {
     vi.restoreAllMocks()
   })
 
-  it('initially sets isOnline state from onlineManager', () => {
+  it('initial state comes from onlineManager.isOnline()', () => {
     const { result } = renderHook(() => useOnlineManager())
     expect(result.current.isOnline).toBe(true)
     expect(result.current.isOffline).toBe(false)
+    expect(result.current.hasNetwork).toBe(true)
+    expect(result.current.manualOffline).toBe(false)
   })
 
-  it('calls subscribe on mount', () => {
+  it('subscribes to onlineManager on mount', () => {
     renderHook(() => useOnlineManager())
     expect(onlineManager.subscribe).toHaveBeenCalled()
   })
 
-  it('updates state when setOnline is called', async () => {
+  it('toggleOffline() forces offline even if network is up', async () => {
     const { result } = renderHook(() => useOnlineManager())
 
-    result.current.setOnline(false)
+    act(() => {
+      result.current.toggleOnline(false)
+    })
+
     await waitFor(() => {
+      expect(result.current.manualOffline).toBe(true)
       expect(result.current.isOnline).toBe(false)
       expect(result.current.isOffline).toBe(true)
+      expect(result.current.hasNetwork).toBe(true)
       expect(onlineManager.setOnline).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it('toggleOnline(true) only re-enables when network is available', async () => {
+    const { result } = renderHook(() => useOnlineManager())
+
+    // 1) Simulate going offline via event
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+    // hasNetwork should now be false
+    expect(result.current.hasNetwork).toBe(false)
+    // forcing online while offline does nothing
+    act(() => {
+      result.current.toggleOnline(true)
+    })
+    expect(result.current.manualOffline).toBe(false)
+    expect(result.current.isOnline).toBe(false)
+
+    // 2) Simulate network return
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+    expect(result.current.hasNetwork).toBe(true)
+
+    // 3) Now user toggles online again
+    act(() => {
+      result.current.toggleOnline(true)
+    })
+
+    await waitFor(() => {
+      expect(result.current.manualOffline).toBe(false)
+      expect(result.current.isOnline).toBe(true)
+      expect(onlineManager.setOnline).toHaveBeenCalledWith(true)
     })
   })
 })

--- a/frontend/src/v2/features/common/hooks/use-online-manager.tsx
+++ b/frontend/src/v2/features/common/hooks/use-online-manager.tsx
@@ -1,36 +1,71 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { onlineManager } from '@tanstack/react-query'
 
-export type OnlineManagerHook = {
-  isOnline: boolean
-  isOffline: boolean
-  setOnline: (online: boolean) => void
-}
+/**
+ * Offline-first toggle hook.
+ * - Detects physical network availability via browser events.
+ * - Allows users to manually switch to offline mode even when network is available.
+ * - Integrates with TanStack Query's onlineManager for query behavior.
+ */
+export function useOnlineManager() {
+  // 1) Physical network availability
+  const [hasNetwork, setHasNetwork] = useState(() => navigator.onLine)
 
-export function useOnlineManager(): OnlineManagerHook {
-  const [isOnline, setIsOnline] = useState<boolean>(onlineManager.isOnline())
+  // 2) User-driven offline mode ("manual offline")
+  const [manualOffline, setManualOffline] = useState(false)
 
+  // 3) Effective online state from TanStack Query
+  const [isOnline, setIsOnline] = useState(() => onlineManager.isOnline())
+
+  // Subscribe to TanStack Query onlineManager changes
   useEffect(() => {
-    const handleOnlineChange = (online: boolean) => {
-      setIsOnline(online)
-      setOnline(online)
-    }
+    const handleChange = online => setIsOnline(online)
+    const unsubscribe = onlineManager.subscribe(handleChange)
+    return unsubscribe
+  }, [])
 
-    const unsubscribe = onlineManager.subscribe(handleOnlineChange)
+  // Sync TanStack Query & internal state whenever network or manualOffline changes
+  useEffect(() => {
+    const effective = hasNetwork && !manualOffline
+    onlineManager.setOnline(effective)
+    setIsOnline(effective)
+  }, [hasNetwork, manualOffline])
+
+  // Listen to browser connectivity changes
+  useEffect(() => {
+    const onOnline = () => setHasNetwork(true)
+    const onOffline = () => setHasNetwork(false)
+
+    window.addEventListener('online', onOnline)
+    window.addEventListener('offline', onOffline)
 
     return () => {
-      unsubscribe()
+      window.removeEventListener('online', onOnline)
+      window.removeEventListener('offline', onOffline)
     }
   }, [])
 
-  const setOnline = (online: boolean) => {
-    setIsOnline(online)
-    onlineManager.setOnline(online)
-  }
+  // User toggle function
+  const toggleOnline = useCallback(
+    shouldBeOnline => {
+      if (shouldBeOnline) {
+        // Only clear manualOffline if there's physical network
+        if (hasNetwork) {
+          setManualOffline(false)
+        }
+      } else {
+        // User forces offline
+        setManualOffline(true)
+      }
+    },
+    [hasNetwork]
+  )
 
   return {
-    isOnline,
-    isOffline: !isOnline,
-    setOnline
+    hasNetwork, // true if browser reports network available
+    manualOffline, // true if user has chosen offline mode
+    isOnline, // effective online state (TanStack Query)
+    isOffline: !isOnline, // effective offline state
+    toggleOnline // call with `true|false` to switch modes
   }
 }


### PR DESCRIPTION
PR séparée pour te montrer les changements autour du hook et du toggle pour le offline

- Le hook
  - fix pour pas repasser online alors qu'il n'y a vraiment plus de network
  - introduction de `hasNetwork` qui check vraiment la connectivité réelle
- Toggle
  -  ajout du disabled state quand il n'y a pas de network