### PR TITLE
fix: compute correct action status in v2 archi

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/GetStatusForAction2.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/GetStatusForAction2.kt
@@ -1,0 +1,41 @@
+package fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action
+
+import fr.gouv.dgampa.rapportnav.config.UseCase
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.action.ActionType
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.status.ActionStatusType
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionNavActionEntity
+import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.interfaces.mission.action.IDBMissionActionRepository
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+@UseCase
+class GetStatusForAction2(
+    private val missionActionsRepository: IDBMissionActionRepository,
+
+) {
+    private val logger = LoggerFactory.getLogger(GetStatusForAction2::class.java)
+
+    fun execute(missionId: Int, actionStartDateTimeUtc: Instant? = null): ActionStatusType {
+        val actions =
+            missionActionsRepository.findAllByMissionId(missionId = missionId)
+                .map {
+                MissionNavActionEntity.fromMissionActionModel(it)
+            }
+
+        if (actions.isEmpty()) {
+            return ActionStatusType.UNKNOWN
+        }
+
+        val lastActionStatus = actions
+            .filter {
+                it.actionType == ActionType.STATUS &&
+                it.startDateTimeUtc != null &&
+                it.startDateTimeUtc!! <= actionStartDateTimeUtc
+            }
+            .maxByOrNull { it.startDateTimeUtc!! }
+
+
+        return lastActionStatus?.status ?: ActionStatusType.UNKNOWN
+    }
+
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/AbstractGetMissionAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/AbstractGetMissionAction.kt
@@ -2,10 +2,10 @@ package fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.status.ActionStatusType
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionActionEntity
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
 
 abstract class AbstractGetMissionAction(
-    private val getStatusForAction: GetStatusForAction
+    private val getStatusForAction: GetStatusForAction2
 ) {
     fun getStatus(action: MissionActionEntity): ActionStatusType? {
         if (action.status != null) return action.status

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/ProcessEnvAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/ProcessEnvAction.kt
@@ -5,7 +5,7 @@ import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.envActions.ControlP
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.envActions.EnvActionControlPlanEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.envActions.EnvActionEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionEnvActionEntity
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.MapEnvActionControlPlans
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.action.FormattedEnvActionControlPlan
 
@@ -13,7 +13,7 @@ import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.action.FormattedEn
 @UseCase
 class ProcessEnvAction(
     private val mapControlPlans: MapEnvActionControlPlans,
-    getStatusForAction: GetStatusForAction,
+    getStatusForAction: GetStatusForAction2,
     private val getComputeEnvTarget: GetComputeEnvTarget
 ) : AbstractGetMissionAction(getStatusForAction) {
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/ProcessFishAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/ProcessFishAction.kt
@@ -3,12 +3,12 @@ package fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2
 import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.fish.fishActions.MissionAction
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionFishActionEntity
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
 
 
 @UseCase
 class ProcessFishAction(
-    getStatusForAction: GetStatusForAction,
+    getStatusForAction: GetStatusForAction2,
     private val getComputeTarget: GetComputeTarget
 ) : AbstractGetMissionAction(getStatusForAction) {
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/ProcessNavAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/action/v2/ProcessNavAction.kt
@@ -2,13 +2,13 @@ package fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2
 
 import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionNavActionEntity
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
 import fr.gouv.dgampa.rapportnav.infrastructure.database.model.mission.action.v2.MissionActionModel
 
 
 @UseCase
 class ProcessNavAction(
-    getStatusForAction: GetStatusForAction,
+    getStatusForAction: GetStatusForAction2,
     private val getComputeTarget: GetComputeTarget
 ) : AbstractGetMissionAction(getStatusForAction) {
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/v2/ProcessEnvActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/v2/ProcessEnvActionTest.kt
@@ -1,6 +1,6 @@
 package fr.gouv.gmampa.rapportnav.domain.use_cases.mission.action.v2
 
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.MapEnvActionControlPlans
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.GetComputeEnvTarget
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.ProcessEnvAction
@@ -25,7 +25,7 @@ class ProcessEnvActionTest {
     private lateinit var processEnvAction: ProcessEnvAction
 
     @MockitoBean
-    private lateinit var getStatusForAction: GetStatusForAction
+    private lateinit var getStatusForAction: GetStatusForAction2
 
     @MockitoBean
     private lateinit var mapControlPlans: MapEnvActionControlPlans

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/v2/ProcessFishActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/v2/ProcessFishActionTest.kt
@@ -1,6 +1,6 @@
 package fr.gouv.gmampa.rapportnav.domain.use_cases.mission.action.v2
 
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.GetComputeTarget
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.ProcessFishAction
 import fr.gouv.gmampa.rapportnav.mocks.mission.TargetMissionMock
@@ -23,7 +23,7 @@ class ProcessFishActionTest {
     private lateinit var processFishAction: ProcessFishAction
 
     @MockitoBean
-    private lateinit var getStatusForAction: GetStatusForAction
+    private lateinit var getStatusForAction: GetStatusForAction2
 
     @MockitoBean
     private lateinit var getComputeTarget: GetComputeTarget

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/v2/ProcessNavActionTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/action/v2/ProcessNavActionTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.domain.use_cases.mission.action.v2
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.action.ActionType
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.*
 import fr.gouv.dgampa.rapportnav.infrastructure.database.model.mission.action.v2.MissionActionModel
 import fr.gouv.gmampa.rapportnav.mocks.mission.TargetMissionMock
@@ -24,7 +24,7 @@ class ProcessNavActionTest {
     private lateinit var processNavAction: ProcessNavAction
 
     @MockitoBean
-    private lateinit var getStatusForAction: GetStatusForAction
+    private lateinit var getStatusForAction: GetStatusForAction2
 
     @MockitoBean
     private lateinit var getComputeTarget: GetComputeTarget

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/status/GetStatusForAction2Tests.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/status/GetStatusForAction2Tests.kt
@@ -1,0 +1,90 @@
+package fr.gouv.gmampa.rapportnav.domain.use_cases.mission.status
+
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.action.ActionType
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.status.ActionStatusType
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.status.UNAVAILABLE_STATUS_AS_STRING
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.GetStatusForAction2
+import fr.gouv.dgampa.rapportnav.infrastructure.database.model.mission.action.v2.MissionActionModel
+import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.interfaces.mission.action.IDBMissionActionRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import java.time.Instant
+import java.util.*
+
+
+@SpringBootTest(classes = [GetStatusForAction2::class])
+class GetStatusForAction2Tests {
+
+    companion object {
+        @Container
+        val container: PostgreSQLContainer<*> = PostgreSQLContainer<Nothing>("postgres:latest")
+            .apply {
+                withDatabaseName("rapportnavdb")
+                withUsername("postgres")
+                withPassword("postgres")
+            }
+
+        init {
+            container.start()
+        }
+    }
+
+    private var missionId: Int = 1
+
+    @MockitoBean
+    private lateinit var missionActionsRepository: IDBMissionActionRepository
+
+    @Autowired
+    private lateinit var getStatusForAction: GetStatusForAction2
+
+    @Test
+    fun `execute Should return Unknown when action is empty list for a mission`() {
+        given(this.missionActionsRepository.findAllByMissionId(missionId = 1)).willReturn(listOf())
+        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = null)
+        assertThat(statusForAction).isEqualTo(ActionStatusType.UNKNOWN)
+    }
+
+    @Test
+    fun `execute Should return the last action status if the last action is a starting status`() {
+        val startDatetime = Instant.parse("2022-01-01T11:00:00Z")
+        val startingAction = MissionActionModel(
+            id = UUID.randomUUID(),
+            missionId = missionId,
+            startDateTimeUtc = startDatetime,
+            status = UNAVAILABLE_STATUS_AS_STRING,
+            actionType = ActionType.STATUS,
+        )
+        val actions = listOf(startingAction)
+        given(this.missionActionsRepository.findAllByMissionId(missionId = 1)).willReturn(actions)
+        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = startDatetime)
+        assertThat(statusForAction).isEqualTo(ActionStatusType.UNAVAILABLE)
+    }
+
+    @Test
+    fun `execute Should return the last action status `() {
+        val startDatetime = Instant.parse("2022-01-01T11:00:00Z")
+        val startingAction = MissionActionModel(
+            id = UUID.randomUUID(),
+            missionId = missionId,
+            startDateTimeUtc = startDatetime,
+            status = UNAVAILABLE_STATUS_AS_STRING,
+            actionType = ActionType.STATUS,
+        )
+        val lastAction = MissionActionModel(
+            id = UUID.randomUUID(),
+            missionId = missionId,
+            startDateTimeUtc = startDatetime.plusSeconds(1),
+            actionType = ActionType.NOTE,
+        )
+        val actions = listOf(startingAction, lastAction)
+        given(this.missionActionsRepository.findAllByMissionId(missionId = 1)).willReturn(actions)
+        val statusForAction = getStatusForAction.execute(missionId = missionId, actionStartDateTimeUtc = startDatetime)
+        assertThat(statusForAction).isEqualTo(ActionStatusType.UNAVAILABLE)
+    }
+}


### PR DESCRIPTION
Je comprenais pas pourquoi le statut des actions était complètement incohérent en local mais en fait, c'est parce qu'on utilisais les ActionStatus v1, cad la table 'mission_action_status' au lieu de 'mission_action'