### PR TITLE
fix: GetNavMissions filter by serviceId

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/GetMissions.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/GetMissions.kt
@@ -3,8 +3,10 @@ package fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2
 import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.MissionEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionEntity2
+import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.GetEnvMissions
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.GetControlUnitsForUser
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.GetUserFromToken
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
@@ -14,12 +16,13 @@ class GetMissions(
     private val getNavMissions: GetNavMissions,
     private val getComputeEnvMission: GetComputeEnvMission,
     private val getComputeNavMission: GetComputeNavMission,
-    private val getControlUnitsForUser: GetControlUnitsForUser
+    private val getControlUnitsForUser: GetControlUnitsForUser,
+    private val getUserFromToken: GetUserFromToken,
 ) {
     private val logger = LoggerFactory.getLogger(GetMissions::class.java)
 
     fun execute(startDateTimeUtc: Instant, endDateTimeUtc: Instant? = null): List<MissionEntity2?> {
-
+        val user: User? = getUserFromToken.execute()
         val envEntities: List<MissionEntity>?  = getEnvMissions.execute(
             startedAfterDateTime = startDateTimeUtc,
             startedBeforeDateTime = endDateTimeUtc,
@@ -29,7 +32,8 @@ class GetMissions(
         )
         val navEntities = getNavMissions.execute(
             startDateTimeUtc = startDateTimeUtc,
-            endDateTimeUtc = endDateTimeUtc
+            endDateTimeUtc = endDateTimeUtc,
+            serviceId = user?.serviceId,
         )
 
         val envMissions = envEntities?.map { getComputeEnvMission.execute(envMission = it) }.orEmpty()

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/GetNavMissions.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/GetNavMissions.kt
@@ -11,15 +11,23 @@ class GetNavMissions(
     private val repository: IMissionNavRepository
 ) {
 
-    fun execute(startDateTimeUtc: Instant, endDateTimeUtc: Instant? = null): List<MissionNavEntity>? {
+    fun execute(startDateTimeUtc: Instant, endDateTimeUtc: Instant? = null, serviceId: Int? = null): List<MissionNavEntity>? {
         val missionModelList = repository.findAll(
             startBeforeDateTime = startDateTimeUtc,
             endBeforeDateTime = endDateTimeUtc ?: Instant.now()
                 .atZone(ZoneOffset.UTC)
                 .plusMonths(1)
                 .withDayOfMonth(1)
-                .toInstant()
+                .toInstant(),
         )
-        return missionModelList.filterNotNull().map { MissionNavEntity.fromMissionModel(it) }
+            .filterNotNull()
+            .let { missions ->
+                if (serviceId != null) {
+                    missions.filter { it.serviceId == serviceId }
+                } else {
+                    missions
+                }
+            }
+        return missionModelList.map { MissionNavEntity.fromMissionModel(it) }
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetMissionsTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetMissionsTest.kt
@@ -11,9 +11,12 @@ import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetComputeNavMissio
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetMissions
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetNavMissions
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.GetControlUnitsForUser
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.GetUserFromToken
+import fr.gouv.gmampa.rapportnav.mocks.user.UserMock
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.anyOrNull
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.bean.override.mockito.MockitoBean
@@ -41,6 +44,9 @@ class GetMissionsTest {
     @MockitoBean
     private lateinit var getControlUnitsForUser: GetControlUnitsForUser
 
+    @MockitoBean
+    private lateinit var getUserFromToken: GetUserFromToken
+
 
     @Test
     fun `should execute return a list of MissionEntity2`()
@@ -59,7 +65,7 @@ class GetMissionsTest {
             missionSource = MissionSourceEnum.RAPPORT_NAV,
             controlUnits = listOf(),
             missionTypes = listOf(MissionTypeEnum.AIR),
-            hasMissionOrder = false
+            hasMissionOrder = false,
         )
 
         val navEntity = MissionNavEntity(
@@ -71,11 +77,12 @@ class GetMissionsTest {
             missionSource = MissionSourceEnum.RAPPORT_NAV
         )
 
-
         val response = MissionEntity2(
             id = 1,
             data = entity
         )
+
+        Mockito.`when`(getUserFromToken.execute()).thenReturn(UserMock.create(serviceId = null))
 
         Mockito.`when`(getEnvMissions.execute(
             startedAfterDateTime = now,
@@ -87,7 +94,8 @@ class GetMissionsTest {
 
         Mockito.`when`(getNavMissions.execute(
             startDateTimeUtc = now,
-            endDateTimeUtc = now
+            endDateTimeUtc = now,
+            serviceId = null
         )).thenReturn(listOf(navEntity))
 
         Mockito.`when`(getControlUnitsForUser.execute()).thenReturn(controlUnits)

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetNavMissionsTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetNavMissionsTest.kt
@@ -25,31 +25,58 @@ class GetNavMissionsTest {
     @Autowired
     private lateinit var getNavMissions: GetNavMissions
 
+    val mockMission = MissionModel(
+        id = UUID.randomUUID(),
+        startDateTimeUtc = Instant.now(),
+        endDateTimeUtc = Instant.now(),
+        isDeleted = false,
+        missionSource = MissionSourceEnum.RAPPORT_NAV,
+        serviceId = 2
+    )
+    val mockMissionWithDifferentService = MissionModel(
+        id = UUID.randomUUID(),
+        startDateTimeUtc = Instant.now(),
+        endDateTimeUtc = Instant.now(),
+        isDeleted = false,
+        missionSource = MissionSourceEnum.RAPPORT_NAV,
+        serviceId = 3
+    )
+
     @Test
     fun `should execute retrieve missions as list of MissionEntity2`()
     {
-        val mockMission = MissionModel(
-            id = UUID.randomUUID(),
-            startDateTimeUtc = Instant.now(),
-            endDateTimeUtc = Instant.now(),
-            isDeleted = false,
-            missionSource = MissionSourceEnum.RAPPORT_NAV,
-            serviceId = 2
-        )
-
         Mockito.`when`(repository.findAll(
             startBeforeDateTime = Instant.parse("2025-04-07T09:23:00.912559Z"),
             endBeforeDateTime = Instant.parse("2025-04-07T09:23:00.912559Z")
-        )).thenReturn(listOf(mockMission))
+        )).thenReturn(listOf(mockMission, mockMissionWithDifferentService))
 
         val missions = getNavMissions.execute(
             startDateTimeUtc = Instant.parse("2025-04-07T09:23:00.912559Z"),
-            endDateTimeUtc = Instant.parse("2025-04-07T09:23:00.912559Z")
+            endDateTimeUtc = Instant.parse("2025-04-07T09:23:00.912559Z"),
+            serviceId = 2
         )
 
         Assertions.assertNotNull(missions)
         Assertions.assertNotNull(missions?.get(0))
         Assertions.assertEquals(1, missions?.size)
         assertThat(missions?.get(0)).isInstanceOf(MissionNavEntity::class.java)
+    }
+
+    @Test
+    fun `should execute retrieve all missions if serviceId is null`()
+    {
+        Mockito.`when`(repository.findAll(
+            startBeforeDateTime = Instant.parse("2025-04-07T09:23:00.912559Z"),
+            endBeforeDateTime = Instant.parse("2025-04-07T09:23:00.912559Z")
+        )).thenReturn(listOf(mockMission, mockMissionWithDifferentService))
+
+        val missions = getNavMissions.execute(
+            startDateTimeUtc = Instant.parse("2025-04-07T09:23:00.912559Z"),
+            endDateTimeUtc = Instant.parse("2025-04-07T09:23:00.912559Z"),
+            serviceId = null
+        )
+
+        Assertions.assertNotNull(missions)
+        Assertions.assertEquals(2, missions?.size)
     }
 }


### PR DESCRIPTION
J'ai rajouté un filtre par serviceId sur GetNavMissions (de la table mission) parce que sinon, ca retournait aussi les missionsNav qu'on créait pour ULAM

<img width="1702" height="508" alt="Screenshot 2025-08-13 at 15 32 20" src="https://github.com/user-attachments/assets/2220aba6-4f37-498d-94d0-b80c8e9176b9" />
