### PR TITLE
fix: pre-create crew when inserting generalInfo for the first time

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/nav/crew/MissionCrewEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/nav/crew/MissionCrewEntity.kt
@@ -40,5 +40,15 @@ data class MissionCrewEntity(
                 updatedAt = crew.updatedAt
             )
         }
+
+        fun fromAgentServiceEntity(agentService: AgentServiceEntity, missionId: Int? = null, missionIdUUID: UUID? = null): MissionCrewEntity {
+            return MissionCrewEntity(
+                missionId = missionId,
+                missionIdUUID = missionIdUUID,
+                comment = null,
+                agent = agentService.agent,
+                role = agentService.role,
+            )
+        }
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/apikey/CreateApiKey.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/apikey/CreateApiKey.kt
@@ -61,7 +61,7 @@ class CreateApiKey(
 
             val saved = repo.save(ApiKeyModel.fromApiKeyEntity(apiKey))
 
-            logger.info("✅ Created new API key for owner='{}', publicId='{}'", owner, publicId)
+            logger.info("Created new API key for owner='{}', publicId='{}'", owner, publicId)
 
             return saved?.toApiKeyEntity() to rawKey
         } catch (ex: Exception) {

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/crew/GetAgentsCrewByMissionId.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/crew/GetAgentsCrewByMissionId.kt
@@ -6,7 +6,7 @@ import fr.gouv.dgampa.rapportnav.domain.repositories.mission.crew.IMissionCrewRe
 import java.util.*
 
 @UseCase
-class GetAgentsCrewByMissionId(private val agentCrewRepository: IMissionCrewRepository) {
+class GetAgentsCrewByMissionId(private val missionCrewRepository: IMissionCrewRepository) {
     val rolePriority = listOf(
         "Commandant",
         "Second capitaine",
@@ -25,13 +25,13 @@ class GetAgentsCrewByMissionId(private val agentCrewRepository: IMissionCrewRepo
     )
 
     fun execute(missionId: Int, commentDefaultsToString: Boolean? = false): List<MissionCrewEntity> {
-        return agentCrewRepository.findByMissionId(missionId = missionId)
+        return missionCrewRepository.findByMissionId(missionId = missionId)
             .map { MissionCrewEntity.fromMissionCrewModel(it) }
             .sortedBy { rolePriority.indexOf(it.role?.title) } //TODO replace by it.role.prority
     }
 
     fun execute(missionIdUUID: UUID, commentDefaultsToString: Boolean? = false): List<MissionCrewEntity> {
-        return agentCrewRepository.findByMissionIdUUID(missionIdUUID = missionIdUUID)
+        return missionCrewRepository.findByMissionIdUUID(missionIdUUID = missionIdUUID)
             .map { MissionCrewEntity.fromMissionCrewModel(it) }
             .sortedBy { rolePriority.indexOf(it.role?.title) } //TODO replace by it.role.prority
     }

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/CreateGeneralInfos.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/CreateGeneralInfos.kt
@@ -1,34 +1,65 @@
 package fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2
 
 import fr.gouv.dgampa.rapportnav.config.UseCase
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.MissionCrewEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.generalInfo.MissionGeneralInfoEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionGeneralInfoEntity2
 import fr.gouv.dgampa.rapportnav.domain.repositories.mission.generalInfo.IMissionGeneralInfoRepository
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2.generalInfo.MissionGeneralInfo2
+import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew.JPAMissionCrewRepository
+import org.slf4j.LoggerFactory
 import java.util.*
 
 @UseCase
 class CreateGeneralInfos(
-    private val generalInfosRepository: IMissionGeneralInfoRepository
+    private val generalInfoRepository: IMissionGeneralInfoRepository,
+    private val crewRepository: JPAMissionCrewRepository
 ) {
+
+    private val logger = LoggerFactory.getLogger(CreateGeneralInfos::class.java)
+
     fun execute(
         missionId: Int? = null,
         missionIdUUID: UUID? = null,
         generalInfo2: MissionGeneralInfo2
-    ): MissionGeneralInfoEntity2 {
-        val generalInfoModel = generalInfosRepository.save(
-            generalInfo2.toMissionGeneralInfoEntity(
-                missionId = missionId,
-                missionIdUUID = missionIdUUID
+    ): MissionGeneralInfoEntity2? {
+        return try {
+            // Try saving main general info
+            val savedGeneralInfo = generalInfoRepository.save(
+                generalInfo2.toMissionGeneralInfoEntity(
+                    missionId = missionId,
+                    missionIdUUID = missionIdUUID
+                )
             )
-        )
-        return MissionGeneralInfoEntity2(
-            data = MissionGeneralInfoEntity(
-                id = generalInfoModel.id,
-                missionId = generalInfoModel.missionId,
-                missionIdUUID = generalInfoModel.missionIdUUID,
-                missionReportType = generalInfo2.missionReportType
+
+            // Save related crew safely (if any)
+            val savedCrew = generalInfo2.crew?.mapNotNull { crew ->
+                try {
+                    val crewEntity = crew.toMissionCrewEntity(missionId = missionId, missionIdUUID = missionIdUUID)
+                    crewRepository.save(crewEntity)
+                } catch (e: Exception) {
+                    // Log and skip crew member if saving fails
+                    logger.info("Failed to save crew member: '{}'", e.message)
+                    null
+                }
+            }
+
+            // Return fully composed entity
+            MissionGeneralInfoEntity2(
+                data = MissionGeneralInfoEntity(
+                    id = savedGeneralInfo.id,
+                    missionId = savedGeneralInfo.missionId,
+                    missionIdUUID = savedGeneralInfo.missionIdUUID,
+                    missionReportType = generalInfo2.missionReportType
+                ),
+                crew = savedCrew?.map { MissionCrewEntity.fromMissionCrewModel(it) }
             )
-        )
+
+        } catch (e: Exception) {
+            // Log top-level failure
+            logger.info("Failed to create general info: '{}'", e.message)
+            null
+        }
     }
 }
+

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/CreateMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/v2/CreateMission.kt
@@ -38,7 +38,11 @@ class CreateMission(
             generalInfo2 = generalInfo2,
             serviceId = serviceId
         ) ?: return null
-        val generalInfosEntity = createGeneralInfos.execute(missionIdUUID = missionNav.id, generalInfo2 = generalInfo2)
+        val generalInfosEntity = createGeneralInfos.execute(
+            missionId = null,
+            missionIdUUID = missionNav.id,
+            generalInfo2 = generalInfo2,
+        )
 
         return MissionEntity2(
             idUUID = missionNav.id,

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/v2/AgentRestController.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/v2/AgentRestController.kt
@@ -1,6 +1,5 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2
 
-import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetAgents
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetAgentsByServiceId
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.GetUserFromToken
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.crew.Agent
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v2/agents")
 class AgentRestController(
-    private val getAgents: GetAgents,
     private val getUserFromToken: GetUserFromToken,
     private val getAgentsByServiceId: GetAgentsByServiceId,
 ) {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/CreateGeneralInfosTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/CreateGeneralInfosTest.kt
@@ -1,0 +1,147 @@
+package fr.gouv.gmampa.rapportnav.domain.use_cases.mission.v2
+
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.AgentEntity
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.generalInfo.MissionGeneralInfoEntity
+import fr.gouv.dgampa.rapportnav.domain.repositories.mission.generalInfo.IMissionGeneralInfoRepository
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.CreateGeneralInfos
+import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.crew.MissionCrew
+import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2.generalInfo.MissionGeneralInfo2
+import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew.JPAMissionCrewRepository
+import fr.gouv.gmampa.rapportnav.mocks.mission.MissionGeneralInfo2Mock
+import fr.gouv.gmampa.rapportnav.mocks.mission.crew.MissionCrewEntityMock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.UUID
+
+@SpringBootTest(classes = [CreateGeneralInfos::class])
+class CreateGeneralInfosTest {
+
+    @Autowired
+    private lateinit var createGeneralInfos: CreateGeneralInfos
+
+    @MockitoBean
+    private lateinit var generalInfoRepository: IMissionGeneralInfoRepository
+
+    @MockitoBean
+    private lateinit var crewRepository: JPAMissionCrewRepository
+
+    @BeforeEach
+    fun setUp() {
+        generalInfoRepository = mock()
+        crewRepository = mock()
+        createGeneralInfos = CreateGeneralInfos(generalInfoRepository, crewRepository)
+    }
+
+    @Test
+    fun `should save general info and crew`() {
+        // Given
+        val missionUuid = UUID.randomUUID()
+
+        val crewEntity = MissionCrewEntityMock.create(agent = AgentEntity(
+            firstName = "Alice",
+            lastName = "",
+        ))
+        val crewModel = crewEntity.toMissionCrewModel()
+
+        val generalInfoInput = MissionGeneralInfo2Mock.create(crew = listOf(MissionCrew.fromMissionCrewEntity(crewEntity)))
+
+        val savedGeneralInfoModel = MissionGeneralInfoEntity(
+            id = 100, missionId = 42, missionIdUUID = missionUuid
+        )
+
+        // Mock behavior
+        whenever(generalInfoRepository.save(any())).thenReturn(savedGeneralInfoModel.toMissionGeneralInfoModel())
+        whenever(crewRepository.save(any())).thenReturn(crewModel)
+
+        // When
+        val result = createGeneralInfos.execute(
+            missionId = 42,
+            missionIdUUID = missionUuid,
+            generalInfo2 = generalInfoInput
+        )
+
+        // Then
+        assertNotNull(result)
+        assertEquals(100, result?.data?.id)
+        assertEquals(missionUuid, result?.data?.missionIdUUID)
+        assertEquals(1, result?.crew?.size)
+        assertEquals("Alice", result?.crew?.first()?.agent?.firstName)
+
+        verify(generalInfoRepository, times(1)).save(any())
+        verify(crewRepository, times(1)).save(any())
+    }
+
+    @Test
+    fun `should save general info even if crew is null`() {
+        val missionId = 1234
+        val generalInfoInput = MissionGeneralInfo2(crew = null)
+        val savedGeneralInfoModel = MissionGeneralInfoEntity(id = missionId)
+
+        whenever(generalInfoRepository.save(any())).thenReturn(savedGeneralInfoModel.toMissionGeneralInfoModel())
+
+        val result = createGeneralInfos.execute(missionId = missionId, generalInfo2 = generalInfoInput)
+
+        assertEquals(missionId, result?.data?.id)
+        assertEquals(null, result?.crew)
+
+        verify(generalInfoRepository, times(1)).save(any())
+        verify(crewRepository, never()).save(any())
+    }
+
+    @Test
+    fun `should return null when general info fails to save`() {
+        val generalInfoInput = MissionGeneralInfo2Mock.create()
+        whenever(generalInfoRepository.save(any())).thenReturn(null)
+
+        val result = createGeneralInfos.execute(generalInfo2 = generalInfoInput)
+
+        assertNull(result)
+        verify(generalInfoRepository, times(1)).save(any())
+        verify(crewRepository, never()).save(any())
+    }
+
+    @Test
+    fun `should skip crew member if saving crew fails`() {
+        val missionUuid = UUID.randomUUID()
+        val crewEntity = MissionCrewEntityMock.create(agent = AgentEntity(firstName = "Bob", lastName = ""))
+        val generalInfoInput = MissionGeneralInfo2Mock.create(crew = listOf(MissionCrew.fromMissionCrewEntity(crewEntity)))
+        val savedGeneralInfoModel = MissionGeneralInfoEntity(id = 200, missionId = 99, missionIdUUID = missionUuid)
+
+        whenever(generalInfoRepository.save(any())).thenReturn(savedGeneralInfoModel.toMissionGeneralInfoModel())
+        whenever(crewRepository.save(any())).thenThrow(RuntimeException("DB error"))
+
+        val result = createGeneralInfos.execute(missionId = 99, missionIdUUID = missionUuid, generalInfo2 = generalInfoInput)
+
+        assertNotNull(result)
+        assertEquals(200, result?.data?.id)
+        assertTrue(result?.crew?.isEmpty() == true)
+
+        verify(generalInfoRepository, times(1)).save(any())
+        verify(crewRepository, times(1)).save(any())
+    }
+
+    @Test
+    fun `should return null when top-level exception is thrown`() {
+        val generalInfoInput = MissionGeneralInfo2Mock.create()
+        whenever(generalInfoRepository.save(any())).thenThrow(RuntimeException("Unexpected failure"))
+
+        val result = createGeneralInfos.execute(generalInfo2 = generalInfoInput)
+
+        assertNull(result)
+        verify(generalInfoRepository, times(1)).save(any())
+        verify(crewRepository, never()).save(any())
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetGeneralInfos2Test.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/mission/v2/GetGeneralInfos2Test.kt
@@ -1,0 +1,129 @@
+package fr.gouv.gmampa.rapportnav.domain.use_cases.mission.v2
+
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.controlResources.LegacyControlUnitEntity
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.ServiceEntity
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.generalInfo.MissionGeneralInfoEntity
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionGeneralInfoEntity2
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetAgentsByServiceId
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetAgentsCrewByMissionId
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetServiceByControlUnit
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.generalInfo.GetMissionGeneralInfoByMissionId
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.CreateGeneralInfos
+import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetGeneralInfo2
+import fr.gouv.gmampa.rapportnav.mocks.mission.crew.MissionCrewEntityMock
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+@SpringBootTest(classes = [GetGeneralInfo2::class])
+class GetGeneralInfos2Test {
+
+    @Autowired
+    private lateinit var getGeneralInfo2: GetGeneralInfo2
+
+    @MockitoBean
+    private lateinit var createGeneralInfos: CreateGeneralInfos
+    @MockitoBean
+    private lateinit var getServiceByControlUnit: GetServiceByControlUnit
+    @MockitoBean
+    private lateinit var getAgentsCrewByMissionId: GetAgentsCrewByMissionId
+    @MockitoBean
+    private lateinit var getMissionGeneralInfoByMissionId: GetMissionGeneralInfoByMissionId
+    @MockitoBean
+    private lateinit var getAgentsByServiceId: GetAgentsByServiceId
+
+    @BeforeEach
+    fun setUp() {
+        createGeneralInfos  = mock()
+        getServiceByControlUnit  = mock()
+        getAgentsCrewByMissionId  = mock()
+        getMissionGeneralInfoByMissionId  = mock()
+        getAgentsByServiceId = mock()
+        getGeneralInfo2 = GetGeneralInfo2(
+            createGeneralInfos,
+            getServiceByControlUnit,
+            getAgentsCrewByMissionId,
+            getMissionGeneralInfoByMissionId,
+            getAgentsByServiceId
+        )
+
+    }
+
+    @Test
+    fun `should return existing general info for missionId`() {
+        val missionId = 10
+        val controlUnits = listOf(LegacyControlUnitEntity(id = 1))
+        val services = listOf(ServiceEntity(id = 123, name = "Customs"))
+        val generalInfo = MissionGeneralInfoEntity(id = 50, missionId = missionId)
+        val crew = listOf(MissionCrewEntityMock.create())
+
+        whenever(getServiceByControlUnit.execute(controlUnits)).thenReturn(services)
+        whenever(getMissionGeneralInfoByMissionId.execute(missionId)).thenReturn(generalInfo)
+        whenever(getAgentsCrewByMissionId.execute(missionId)).thenReturn(crew)
+
+        val result = getGeneralInfo2.execute(missionId, controlUnits)
+
+        assertEquals(services, result.services)
+        assertEquals(crew, result.crew)
+        assertEquals(generalInfo, result.data)
+        verify(createGeneralInfos, never()).execute(any(), any(), any())
+    }
+
+    @Test
+    fun `should create general info when not found`() {
+        val missionId = 42
+        val controlUnits = listOf(LegacyControlUnitEntity(id = 1))
+        val services = listOf(ServiceEntity(id = 99, name = "Navy"))
+        val created = MissionGeneralInfoEntity(id = 77, missionId = missionId)
+        val crew = listOf(MissionCrewEntityMock.create())
+
+        whenever(getServiceByControlUnit.execute(controlUnits)).thenReturn(services)
+        whenever(getMissionGeneralInfoByMissionId.execute(missionId)).thenReturn(null)
+        whenever(createGeneralInfos.execute(anyOrNull(), anyOrNull(), any())).thenReturn(MissionGeneralInfoEntity2(data = created))
+        whenever(getAgentsCrewByMissionId.execute(missionId)).thenReturn(crew)
+
+        val result = getGeneralInfo2.execute(missionId, controlUnits)
+
+        assertEquals(services.first().id, result.services?.first()?.id)
+        verify(createGeneralInfos, times(1)).execute(anyOrNull(), anyOrNull(), any())
+    }
+
+    @Test
+    fun `should return empty crew when crew fetching fails`() {
+        val missionId = 5
+        val services = listOf(ServiceEntity(id = 1, name = "Navy"))
+        val generalInfo = MissionGeneralInfoEntity(id = 99, missionId = missionId)
+
+        whenever(getServiceByControlUnit.execute(null)).thenReturn(services)
+        whenever(getMissionGeneralInfoByMissionId.execute(missionId)).thenReturn(generalInfo)
+        whenever(getAgentsCrewByMissionId.execute(missionId)).thenThrow(RuntimeException("DB error"))
+
+        val result = getGeneralInfo2.execute(missionId)
+
+        assertTrue(result.crew!!.isEmpty())
+        verify(getAgentsCrewByMissionId).execute(missionId)
+    }
+
+    @Test
+    fun `should return empty services when fetch fails`() {
+        val missionId = 123
+        whenever(getServiceByControlUnit.execute(null)).thenThrow(RuntimeException("network"))
+        whenever(getMissionGeneralInfoByMissionId.execute(missionId)).thenReturn(MissionGeneralInfoEntity(id = 1))
+
+        val result = getGeneralInfo2.execute(missionId)
+
+        assertTrue(result.services?.isEmpty() == true)
+    }
+
+}

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/mocks/mission/MissionGeneralInfo2Mock.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/mocks/mission/MissionGeneralInfo2Mock.kt
@@ -3,6 +3,7 @@ package fr.gouv.gmampa.rapportnav.mocks.mission
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.MissionTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionReinforcementTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionReportTypeEnum
+import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.crew.MissionCrew
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2.generalInfo.MissionGeneralInfo2
 import java.time.Instant
 
@@ -13,7 +14,8 @@ object MissionGeneralInfo2Mock {
         missionReportType: MissionReportTypeEnum = MissionReportTypeEnum.FIELD_REPORT,
         missionTypes: List<MissionTypeEnum> = listOf(MissionTypeEnum.SEA),
         reinforcementType: MissionReinforcementTypeEnum? = null,
-        nbHourAtSea: Int? = null
+        nbHourAtSea: Int? = null,
+        crew: List<MissionCrew>? = null,
     ): MissionGeneralInfo2 {
         return MissionGeneralInfo2(
             startDateTimeUtc = startDateTimeUtc,
@@ -22,7 +24,8 @@ object MissionGeneralInfo2Mock {
             missionTypes = missionTypes,
             reinforcementType = reinforcementType,
             nbHourAtSea = nbHourAtSea,
-            missionId = 0
+            missionId = 0,
+            crew = crew
         )
     }
 }


### PR DESCRIPTION
Pour fixer ce bug un peu chiant pour les bordées A des PAMs
En gros, vu qu'on met le serviceId quand on créé pour la premiere fois les generalInfos, le dropdown est rempli mais quand on selectionne la valeur sélectionnée, ca créé pas de crew.
Du coup, j'ai rajouté l'auto création du crew quand on créé la row generalInfos, on en avait parlé.
Ma prochaine feature, c'est de changer la partie crew pour les PAM et je devrai pré-remplir de toute facon donc j'ai pris de l'avance.

**Dis moi si c'est problématique pour ULAM stp**

.
.
.

https://github.com/user-attachments/assets/15b3483f-63ba-421e-a053-75e60a86530a

