### PR TITLE
feat: show flagstate and externalId for vessels on Fish actions

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/model/v2/BaseMissionFishActionData.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/model/v2/BaseMissionFishActionData.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2
 
+import com.neovisionaries.i18n.CountryCode
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.fish.fishActions.*
 
 interface BaseMissionFishActionData {
@@ -7,6 +8,7 @@ interface BaseMissionFishActionData {
     val vesselName: String?
     val internalReferenceNumber: String?
     val externalReferenceNumber: String?
+    val flagState: CountryCode?
     val districtCode: String?
     val faoAreas: List<String>?
     val fishActionType: MissionActionType?

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/model/v2/MissionFishAction.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/model/v2/MissionFishAction.kt
@@ -53,6 +53,7 @@ class MissionFishAction(
                     vesselName = fishAction.vesselName,
                     internalReferenceNumber = fishAction.internalReferenceNumber,
                     externalReferenceNumber = fishAction.externalReferenceNumber,
+                    flagState = fishAction.flagState,
                     districtCode = fishAction.districtCode,
                     faoAreas = fishAction.faoAreas?: listOf(),
                     emitsVms = fishAction.emitsVms,

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/model/v2/MissionFishActionData.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/bff/model/v2/MissionFishActionData.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2
 
+import com.neovisionaries.i18n.CountryCode
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.fish.fishActions.*
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionFishActionEntity
 import java.time.Instant
@@ -11,6 +12,7 @@ class MissionFishActionData(
     override val vesselName: String? = null,
     override val internalReferenceNumber: String? = null,
     override val externalReferenceNumber: String? = null,
+    override val flagState: CountryCode? = null,
     override val districtCode: String? = null,
     override val faoAreas: List<String> = listOf(),
     override val fishActionType: MissionActionType,

--- a/frontend/src/v2/features/common/components/ui/__tests__/__snapshots__/vessel-name.test.tsx.snap
+++ b/frontend/src/v2/features/common/components/ui/__tests__/__snapshots__/vessel-name.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`VesselName > should match the snapshot 1`] = `
       <p
         class="sc-iRcyzz sc-fFmWCW fjDFZW hAFmCO"
         color="#282F3E"
+        data-testid="vessel-name"
         font-size="13"
         weight="bold"
       >
@@ -41,6 +42,7 @@ exports[`VesselName > should match the snapshot 1`] = `
     <p
       class="sc-iRcyzz sc-fFmWCW fjDFZW hAFmCO"
       color="#282F3E"
+      data-testid="vessel-name"
       font-size="13"
       weight="bold"
     >

--- a/frontend/src/v2/features/common/components/ui/__tests__/vessel-name.test.tsx
+++ b/frontend/src/v2/features/common/components/ui/__tests__/vessel-name.test.tsx
@@ -1,14 +1,27 @@
 import { vi } from 'vitest'
-import { render } from '../../../../../../test-utils'
+import { render, screen } from '../../../../../../test-utils'
 import VesselName from '../vessel-name'
 
-const handleSubmit = vi.fn()
 describe('VesselName', () => {
-  beforeEach(() => {
-    handleSubmit.mockClear()
-  })
   it('should match the snapshot', () => {
     const wrapper = render(<VesselName name="ultima navire" />)
     expect(wrapper).toMatchSnapshot()
+  })
+  it('should render vessel name with optional fields', () => {
+    render(<VesselName name="Poseidon" flagState="FR" externalReferenceNumber="REF-42" />)
+
+    expect(screen.getByTestId('vessel-name')).toHaveTextContent('Poseidon - FR - REF-42')
+  })
+
+  it('should not include missing fields', () => {
+    render(<VesselName name="Poseidon" flagState="FR" />)
+
+    expect(screen.getByTestId('vessel-name')).toHaveTextContent('Poseidon - FR')
+  })
+
+  it('should render fallback when all props are undefined', () => {
+    render(<VesselName />)
+
+    expect(screen.getByTestId('vessel-name')).toHaveTextContent('')
   })
 })

--- a/frontend/src/v2/features/common/components/ui/vessel-name.tsx
+++ b/frontend/src/v2/features/common/components/ui/vessel-name.tsx
@@ -4,13 +4,18 @@ import { useVessel } from '../../hooks/use-vessel'
 
 type VesselNameProps = {
   name?: string
+  flagState?: string
+  externalReferenceNumber?: string
 }
 
-export const VesselName: React.FC<VesselNameProps> = ({ name }) => {
-  const { getVesselName } = useVessel()
+export const VesselName: React.FC<VesselNameProps> = ({ name, flagState, externalReferenceNumber }) => {
+  const { getFullVesselName } = useVessel()
+
+  const text = getFullVesselName(name, flagState, externalReferenceNumber)
+
   return (
-    <Text as="h3" weight="bold" color={THEME.color.gunMetal}>
-      {getVesselName(name)}
+    <Text as="h3" weight="bold" color={THEME.color.gunMetal} data-testid="vessel-name">
+      {text}
     </Text>
   )
 }

--- a/frontend/src/v2/features/common/hooks/__tests__/use-vessel.test.tsx
+++ b/frontend/src/v2/features/common/hooks/__tests__/use-vessel.test.tsx
@@ -3,6 +3,7 @@ import { VesselTypeEnum } from '@common/types/mission-types'
 import { renderHook } from '@testing-library/react'
 import { ModuleType } from '../../types/module-type'
 import { useVessel } from '../use-vessel'
+import { describe } from 'vitest'
 
 describe('useVessel', () => {
   it('should have every vessel type for ULAM module ', () => {
@@ -59,6 +60,39 @@ describe('useVessel', () => {
     const { result } = renderHook(() => useVessel())
     Object.keys(VesselTypeEnum).forEach(type => {
       expect(result.current.getVesselType(type as VesselTypeEnum)).toBeDefined()
+    })
+  })
+
+  describe('getFullVesselName', () => {
+    it('should return full vessel name with only name', () => {
+      const { result } = renderHook(() => useVessel())
+
+      expect(result.current.getFullVesselName('Poseidon')).toEqual('Poseidon')
+    })
+
+    it('should return full vessel name with name and external reference number', () => {
+      const { result } = renderHook(() => useVessel())
+
+      expect(result.current.getFullVesselName('Poseidon', undefined, 'REF-123')).toEqual('Poseidon - REF-123')
+    })
+
+    it('should return full vessel name with name and flag state', () => {
+      const { result } = renderHook(() => useVessel())
+
+      expect(result.current.getFullVesselName('Poseidon', 'FR')).toEqual('Poseidon - FR')
+    })
+
+    it('should return full vessel name with all fields', () => {
+      const { result } = renderHook(() => useVessel())
+
+      expect(result.current.getFullVesselName('Poseidon', 'FR', 'REF-123')).toEqual('Poseidon - FR - REF-123')
+    })
+
+    it('should handle undefined name gracefully (delegated to getVesselName)', () => {
+      const { result } = renderHook(() => useVessel())
+
+      // getVesselName(undefined) returns ""
+      expect(result.current.getFullVesselName()).toEqual('')
     })
   })
 })

--- a/frontend/src/v2/features/common/hooks/use-vessel.tsx
+++ b/frontend/src/v2/features/common/hooks/use-vessel.tsx
@@ -57,6 +57,7 @@ const VESSEL_TYPE_REGISTRY: VesselTypeRegistry = {
 
 interface VesselHook {
   getVesselName: (name?: string) => string | undefined
+  getFullVesselName: (name?: string, flagState?: string, externalReferenceNumber?: string) => string | undefined
   getVesselSize: (size?: VesselSizeEnum) => string | undefined
   getVesselTypeName: (size?: VesselTypeEnum) => string | undefined
   vesselTypeOptions: { label: string; value: VesselTypeEnum }[]
@@ -83,6 +84,28 @@ export function useVessel(): VesselHook {
   const getVesselName = (name?: string): string | undefined =>
     !name ? '' : name === 'UNKNOWN' ? 'Navire inconnu' : name
 
+  const getFullVesselName = (
+    name?: string,
+    flagState?: string,
+    externalReferenceNumber?: string
+  ): string | undefined => {
+    const parts: string[] = []
+
+    // Always show the formatted vessel name
+    parts.push(getVesselName(name))
+
+    // Optional fields
+    if (flagState) {
+      parts.push(flagState)
+    }
+
+    if (externalReferenceNumber) {
+      parts.push(externalReferenceNumber)
+    }
+
+    return parts.join(' - ')
+  }
+
   const getVesselTypeByModule = (moduleType: ModuleType) => {
     const entry =
       moduleType === ModuleType.ULAM
@@ -97,6 +120,7 @@ export function useVessel(): VesselHook {
   return {
     getVesselType,
     getVesselName,
+    getFullVesselName,
     getVesselSize,
     getVesselTypeName,
     getVesselTypeByModule,

--- a/frontend/src/v2/features/common/types/mission-action.ts
+++ b/frontend/src/v2/features/common/types/mission-action.ts
@@ -126,6 +126,7 @@ export interface MissionFishActionData extends MissionActionData {
   vesselName?: string
   internalReferenceNumber?: string
   externalReferenceNumber?: string
+  flagState?: string
   districtCode?: string
   faoAreas: string[]
   fishActionType: MissionActionType

--- a/frontend/src/v2/features/mission-action/components/elements/mission-action-item-fish-control.tsx
+++ b/frontend/src/v2/features/mission-action/components/elements/mission-action-item-fish-control.tsx
@@ -40,7 +40,11 @@ const MissionActionItemFishControl: FC<{
                 data-testid={'action-control-nav'}
               >
                 <Stack.Item style={{ width: '100%' }}>
-                  <VesselName name={values.vesselName} />
+                  <VesselName
+                    name={values.vesselName}
+                    flagState={values.flagState}
+                    externalReferenceNumber={values.externalReferenceNumber}
+                  />
                 </Stack.Item>
                 <Stack.Item grow={1}>
                   <Field name="dates">

--- a/frontend/src/v2/features/mission-timeline/components/ui/__tests__/__snapshots__/mission-timeline-item-surveillance-card-title.test.tsx.snap
+++ b/frontend/src/v2/features/mission-timeline/components/ui/__tests__/__snapshots__/mission-timeline-item-surveillance-card-title.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`MissionTimelineItemSurveillanceCardTitle > should match the snapshot 1`
       <p
         class="sc-iRcyzz sc-fFmWCW kaCwCU hAFmCO"
         color="#282F3E"
+        data-testid="mission-timeline-item-card-title"
         font-size="13"
         weight="medium"
       >
@@ -44,6 +45,7 @@ exports[`MissionTimelineItemSurveillanceCardTitle > should match the snapshot 1`
     <p
       class="sc-iRcyzz sc-fFmWCW kaCwCU hAFmCO"
       color="#282F3E"
+      data-testid="mission-timeline-item-card-title"
       font-size="13"
       weight="medium"
     >

--- a/frontend/src/v2/features/mission-timeline/components/ui/__tests__/mission-timeline-item-fish-control-card-title.test.tsx
+++ b/frontend/src/v2/features/mission-timeline/components/ui/__tests__/mission-timeline-item-fish-control-card-title.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '../../../../../../test-utils'
+import { MissionTimelineAction } from '../../../types/mission-timeline-output'
+import MissionTimelineItemFishControlCardTitle from '../mission-timeline-item-fish-control-card-title.tsx'
+import { MissionActionType } from '@common/types/fish-mission-types.ts'
+
+describe('MissionTimelineItemFishControlCardTitle', () => {
+  const baseAction: Partial<MissionTimelineAction> = {
+    fishActionType: MissionActionType.SEA_CONTROL,
+    vesselName: 'Poseidon'
+  }
+
+  it('shows mandatory fields (action type + vessel name)', () => {
+    render(<MissionTimelineItemFishControlCardTitle action={baseAction as MissionTimelineAction} />)
+
+    expect(screen.getByText('Contrôle en mer - Poseidon', { exact: false })).toBeInTheDocument()
+  })
+
+  it('includes externalReferenceNumber when present', () => {
+    const action = {
+      ...baseAction,
+      externalReferenceNumber: 'REF-123'
+    } as MissionTimelineAction
+
+    render(<MissionTimelineItemFishControlCardTitle action={action} />)
+
+    expect(screen.getByText('REF-123', { exact: false })).toBeInTheDocument()
+  })
+
+  it('includes flagState when present', () => {
+    const action = {
+      ...baseAction,
+      flagState: 'FR'
+    } as MissionTimelineAction
+
+    render(<MissionTimelineItemFishControlCardTitle action={action} />)
+
+    expect(screen.getByText('FR', { exact: false })).toBeInTheDocument()
+  })
+
+  it('includes both optional fields when present', () => {
+    const action = {
+      ...baseAction,
+      externalReferenceNumber: 'REF-999',
+      flagState: 'FR'
+    } as MissionTimelineAction
+
+    render(<MissionTimelineItemFishControlCardTitle action={action} />)
+
+    expect(screen.getByText('Contrôle en mer - Poseidon - FR - REF-999')).toBeInTheDocument()
+  })
+
+  it('does not include externalReferenceNumber when null', () => {
+    const action = {
+      ...baseAction,
+      externalReferenceNumber: null
+    } as MissionTimelineAction
+
+    render(<MissionTimelineItemFishControlCardTitle action={action} />)
+
+    const text = screen.getByTestId('mission-timeline-item-card-title').textContent
+    expect(text).not.toContain('null')
+  })
+
+  it('does not include flagState when null', () => {
+    const action = {
+      ...baseAction,
+      flagState: null
+    } as MissionTimelineAction
+
+    render(<MissionTimelineItemFishControlCardTitle action={action} />)
+
+    const text = screen.getByTestId('mission-timeline-item-card-title').textContent
+    expect(text).not.toContain('null')
+  })
+
+  it('does not render awkward separators when optional fields missing', () => {
+    const action = {
+      ...baseAction,
+      externalReferenceNumber: undefined,
+      flagState: undefined
+    } as MissionTimelineAction
+
+    render(<MissionTimelineItemFishControlCardTitle action={action} />)
+
+    const text = screen.getByTestId('mission-timeline-item-card-title').textContent
+
+    // Should be exactly two items joined by " - "
+    expect(text).toBe('Contrôle en mer - Poseidon ')
+  })
+})

--- a/frontend/src/v2/features/mission-timeline/components/ui/mission-timeline-item-card-title.tsx
+++ b/frontend/src/v2/features/mission-timeline/components/ui/mission-timeline-item-card-title.tsx
@@ -8,7 +8,13 @@ type MissionTimelineItemCardTitleProps = {
 
 const MissionTimelineItemCardTitle: React.FC<MissionTimelineItemCardTitleProps> = ({ text, bold, ...props }) => {
   return (
-    <Text as="h3" weight="medium" color={THEME.color.gunMetal} {...props}>
+    <Text
+      as="h3"
+      weight="medium"
+      color={THEME.color.gunMetal}
+      {...props}
+      data-testid="mission-timeline-item-card-title"
+    >
       {`${text} `}
       <b>{bold}</b>
     </Text>

--- a/frontend/src/v2/features/mission-timeline/components/ui/mission-timeline-item-fish-control-card-title.tsx
+++ b/frontend/src/v2/features/mission-timeline/components/ui/mission-timeline-item-fish-control-card-title.tsx
@@ -1,15 +1,19 @@
 import { formatMissionActionTypeForHumans } from '@common/types/fish-mission-types'
-import { vesselNameOrUnknown } from '@common/utils/action-utils'
 import { FC } from 'react'
 import { MissionTimelineAction } from '../../types/mission-timeline-output'
 import MissionTimelineItemCardTitle from './mission-timeline-item-card-title'
+import { useVessel } from '../../../common/hooks/use-vessel.tsx'
 
 const MissionTimelineItemFishControlCardTitle: FC<{ action?: MissionTimelineAction }> = ({ action }) => {
-  return (
-    <MissionTimelineItemCardTitle
-      text={`${formatMissionActionTypeForHumans(action?.fishActionType)} - ${vesselNameOrUnknown(action?.vesselName)}`}
-    />
-  )
+  const { getFullVesselName } = useVessel()
+  const parts: string[] = []
+
+  parts.push(formatMissionActionTypeForHumans(action.fishActionType))
+  parts.push(getFullVesselName(action?.vesselName, action?.flagState, action?.externalReferenceNumber))
+
+  const text = parts.join(' - ')
+
+  return <MissionTimelineItemCardTitle text={text} />
 }
 
 export default MissionTimelineItemFishControlCardTitle

--- a/frontend/src/v2/features/mission-timeline/hooks/use-timeline.tsx
+++ b/frontend/src/v2/features/mission-timeline/hooks/use-timeline.tsx
@@ -134,6 +134,8 @@ export function useTimeline(): TimelineHook {
       endDateTimeUtc: action.data?.endDateTimeUtc,
       vesselId: action.data?.vesselId,
       vesselName: action.data?.vesselName,
+      externalReferenceNumber: action.data?.externalReferenceNumber,
+      flagState: action?.data?.flagState,
       observations: action.data?.observationsByUnit,
       networkSyncStatus: action.networkSyncStatus
     }

--- a/frontend/src/v2/features/mission-timeline/types/mission-timeline-output.ts
+++ b/frontend/src/v2/features/mission-timeline/types/mission-timeline-output.ts
@@ -29,6 +29,8 @@ export type MissionTimelineAction = {
   endDateTimeUtc?: string
   vesselId?: number
   vesselName?: string
+  externalReferenceNumber?: string
+  flagState?: string
   actionNumberOfControls?: number
   actionTargetType?: ActionTargetTypeEnum
   vehicleType?: VehicleTypeEnum


### PR DESCRIPTION
Ajout de ces infos pour rendre la lecture plus facile pour les commandants

<img width="937" height="217" alt="Screenshot 2025-11-25 at 11 12 42" src="https://github.com/user-attachments/assets/7dec1b1d-6619-4971-b1d2-942e6cddbc2d" />
