### PR TITLE
feat: make observationsByUnit not mandatory and blocking

### DIFF
--- a/backend/src/main/resources/wiremock/env/mission.json
+++ b/backend/src/main/resources/wiremock/env/mission.json
@@ -27,7 +27,7 @@
   ],
   "openBy": null,
   "completedBy": null,
-  "observationsByUnit": "bla",
+  "observationsByUnit": null,
   "observationsCacem": null,
   "observationsCnsp": null,
   "facade": null,

--- a/frontend/src/v2/features/pam/components/element/general-info/mission-general-information-form-pam.tsx
+++ b/frontend/src/v2/features/pam/components/element/general-info/mission-general-information-form-pam.tsx
@@ -136,7 +136,6 @@ const MissionGeneralInformationFormPam: FC<{
 
                 <Stack.Item style={{ width: '100%' }}>
                   <FormikTextarea
-                    isRequired={true}
                     isLight={false}
                     name="observations"
                     data-testid="mission-general-observation"

--- a/frontend/src/v2/features/pam/hooks/__tests__/use-pam-mission-general-information-form.test.tsx
+++ b/frontend/src/v2/features/pam/hooks/__tests__/use-pam-mission-general-information-form.test.tsx
@@ -79,7 +79,7 @@ describe('usePamMissionGeneralInformationForm', () => {
         consumedGOInLiters: 20,
         consumedFuelInLiters: 30,
         nbrOfRecognizedVessel: 1,
-        observations: 'OK',
+        observations: null,
         crew: [{}]
       })
       expect(valid).toBe(true)

--- a/frontend/src/v2/features/pam/hooks/use-pam-mission-general-information-form.tsx
+++ b/frontend/src/v2/features/pam/hooks/use-pam-mission-general-information-form.tsx
@@ -89,14 +89,6 @@ export const usePamMissionGeneralInfoForm = (
         schema => schema.nonNullable().required()
       )(isMissionFinished && !isMissionInterServices),
 
-      observations: conditionallyRequired(
-        () => string().nullable(),
-        [],
-        true,
-        'Observations are required',
-        schema => schema.nonNullable().required()
-      )(isMissionFinished && !isMissionInterServices),
-
       crew: conditionallyRequired(
         () => array().min(1, 'At least one crew member is required when mission is finished').nullable(),
         [],


### PR DESCRIPTION
Après avoir parlé avec Clémence, on a décidé de pas mettre le champ observationsByUnit blocking parce qu'il sert à rien pour les stats