### PR TITLE
fix: remove backend warnings

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -10,7 +10,7 @@ description = "RapportNav"
 
 val kotlinVersion by extra("2.2.21")
 val serializationVersion by extra("1.6.2")
-val springVersion by extra("3.5.7")
+val springVersion by extra("3.5.8")
 val testcontainersVersion by extra("1.19.3")
 val flywayVersion by extra("10.10.0")
 
@@ -20,7 +20,7 @@ plugins {
   kotlin("jvm") version "2.2.21"
   kotlin("plugin.spring") version "2.2.21"
   kotlin("plugin.jpa") version "2.2.21"
-  id("org.springframework.boot") version "3.5.7"
+  id("org.springframework.boot") version "3.5.8"
   id("io.spring.dependency-management") version "1.1.4"
   id("org.owasp.dependencycheck") version "12.1.0"
   id("org.flywaydb.flyway") version "10.10.0"

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/config/JwtEncodingConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/config/JwtEncodingConfig.kt
@@ -16,7 +16,7 @@ import javax.crypto.spec.SecretKeySpec
  */
 @Configuration
 class JwtEncodingConfig(
-    @Value("\${JWT_SECURITY_KEY}")
+    @param:Value("\${JWT_SECURITY_KEY}")
     private val jwtKey: String,
 ) {
     private val secretKey = SecretKeySpec(jwtKey.toByteArray(), "HmacSHA256")

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/MissionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/MissionEntity.kt
@@ -126,7 +126,7 @@ data class MissionEntity(
             return MissionStatusEnum.UNAVAILABLE
         }
 
-        if (endDateTimeUtc != null && Instant.parse(endDateTimeUtc.toString()).isBefore(compareDate)) {
+        if (Instant.parse(endDateTimeUtc.toString()).isBefore(compareDate)) {
             return MissionStatusEnum.ENDED
         }
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/env/controlResources/LegacyControlUnitEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/env/controlResources/LegacyControlUnitEntity.kt
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class LegacyControlUnitEntity @JsonCreator constructor(
-    @JsonProperty("id") val id: Int,
-    @JsonProperty("administration") val administration: String? = null,
-    @JsonProperty("isArchived") val isArchived: Boolean? = false,
-    @JsonProperty("name") val name: String? = null,
-    @JsonProperty("resources") var resources: MutableList<LegacyControlUnitResourceEntity>? = mutableListOf(),
-    @JsonProperty("contact") val contact: String? = null
+    @field:JsonProperty("id") val id: Int,
+    @field:JsonProperty("administration") val administration: String? = null,
+    @field:JsonProperty("isArchived") val isArchived: Boolean? = false,
+    @field:JsonProperty("name") val name: String? = null,
+    @field:JsonProperty("resources") var resources: MutableList<LegacyControlUnitResourceEntity>? = mutableListOf(),
+    @field:JsonProperty("contact") val contact: String? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/env/controlResources/LegacyControlUnitResourceEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/env/controlResources/LegacyControlUnitResourceEntity.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class LegacyControlUnitResourceEntity @JsonCreator constructor(
-    @JsonProperty("id") val id: Int,
-    @JsonProperty("controlUnitId") val controlUnitId: Int? = null,
-    @JsonProperty("name") val name: String? = null,
+    @field:JsonProperty("id") val id: Int,
+    @field:JsonProperty("controlUnitId") val controlUnitId: Int? = null,
+    @field:JsonProperty("name") val name: String? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/env/envActions/EnvActionEntity.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/mission/env/envActions/EnvActionEntity.kt
@@ -32,7 +32,7 @@ abstract class EnvActionEntity(
     open val completedBy: String? = null,
     open val completion: ActionCompletionEnum? = null,
     open val controlPlans: List<EnvActionControlPlanEntity>? = listOf(),
-    @JsonDeserialize(using = GeometryDeserializer::class) open val geom: Geometry? = null,
+    @field:JsonDeserialize(using = GeometryDeserializer::class) open val geom: Geometry? = null,
     open val isAdministrativeControl: Boolean? = null,
     open val isComplianceWithWaterRegulationsControl: Boolean? = null,
     open val isSafetyEquipmentAndStandardsComplianceControl: Boolean? = null,

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionAEM.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionAEM.kt
@@ -20,9 +20,9 @@ import java.nio.file.StandardCopyOption
 class ExportMissionAEM(
     private val getMissionById: GetMission,
     private val fillAEMExcelRow: FillAEMExcelRow,
-    @Value("\${rapportnav.aem.template.path}") private val aemTemplatePath: String,
-    @Value("\${rapportnav.aem.tmp_xlsx.path}") private val aemTmpXLSXPath: String,
-    @Value("\${rapportnav.aem.tmp_ods.path}") private val aemTmpODSPath: String,
+    @param:Value("\${rapportnav.aem.template.path}") private val aemTemplatePath: String,
+    @param:Value("\${rapportnav.aem.tmp_xlsx.path}") private val aemTmpXLSXPath: String,
+    @param:Value("\${rapportnav.aem.tmp_ods.path}") private val aemTmpODSPath: String,
 
     ) {
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionRapportPatrouille.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionRapportPatrouille.kt
@@ -44,9 +44,9 @@ class ExportMissionRapportPatrouille(
     private val getInfoAboutNavAction: GetInfoAboutNavAction,
     private val formatDateTime: FormatDateTime,
     private val getServiceById: GetServiceById,
-    @Value("\${rapportnav.rapport-patrouille.template.path}") private val docTemplatePath: String,
-    @Value("\${rapportnav.rapport-patrouille.tmp_docx.path}") private val docTmpDOCXPath: String,
-    @Value("\${rapportnav.rapport-patrouille.tmp_odt.path}") private val docTmpODTPath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.template.path}") private val docTemplatePath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.tmp_docx.path}") private val docTmpDOCXPath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.tmp_odt.path}") private val docTmpODTPath: String,
 ) {
 
     private val logger = LoggerFactory.getLogger(ExportMissionRapportPatrouille::class.java)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionAEMSingle.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionAEMSingle.kt
@@ -20,9 +20,9 @@ class ExportMissionAEMSingle(
     private val getMission: GetMission,
     private val fillAEMExcelRow: FillAEMExcelRow,
     private val formatDateTime: FormatDateTime,
-    @Value("\${rapportnav.aem.template.path}") private val aemTemplatePath: String,
-    @Value("\${rapportnav.aem.tmp_xlsx.path}") private val aemTmpXLSXPath: String,
-    @Value("\${rapportnav.aem.tmp_ods.path}") private val aemTmpODSPath: String,
+    @param:Value("\${rapportnav.aem.template.path}") private val aemTemplatePath: String,
+    @param:Value("\${rapportnav.aem.tmp_xlsx.path}") private val aemTmpXLSXPath: String,
+    @param:Value("\${rapportnav.aem.tmp_ods.path}") private val aemTmpODSPath: String,
 ) {
 
     private val logger = LoggerFactory.getLogger(ExportMissionAEMSingle::class.java)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionAEMSingle2.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionAEMSingle2.kt
@@ -21,9 +21,9 @@ import java.nio.file.StandardCopyOption
 
 @UseCase
 class ExportMissionAEMSingle2(
-    @Value("\${rapportnav.aem.template.path}") private val aemTemplatePath: String,
-    @Value("\${rapportnav.aem.tmp_xlsx.path}") private val aemTmpXLSXPath: String,
-    @Value("\${rapportnav.aem.tmp_ods.path}") private val aemTmpODSPath: String,
+    @param:Value("\${rapportnav.aem.template.path}") private val aemTemplatePath: String,
+    @param:Value("\${rapportnav.aem.tmp_xlsx.path}") private val aemTmpXLSXPath: String,
+    @param:Value("\${rapportnav.aem.tmp_ods.path}") private val aemTmpODSPath: String,
     private val fillAEMExcelRow: FillAEMExcelRow,
     private val getEnvMissionById2: GetEnvMissionById2,
     private val getEnvActionByMissionId: GetComputeEnvActionListByMissionId,

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingle.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingle.kt
@@ -48,9 +48,9 @@ class ExportMissionPatrolSingle(
     private val getInfoAboutNavAction: GetInfoAboutNavAction,
     private val formatDateTime: FormatDateTime,
     private val getServiceById: GetServiceById,
-    @Value("\${rapportnav.rapport-patrouille.template.path}") private val docTemplatePath: String,
-    @Value("\${rapportnav.rapport-patrouille.tmp_docx.path}") private val docTmpDOCXPath: String,
-    @Value("\${rapportnav.rapport-patrouille.tmp_odt.path}") private val docTmpODTPath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.template.path}") private val docTemplatePath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.tmp_docx.path}") private val docTmpDOCXPath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.tmp_odt.path}") private val docTmpODTPath: String,
 ) {
 
     private val logger = LoggerFactory.getLogger(ExportMissionPatrolSingle::class.java)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingle2.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/v2/ExportMissionPatrolSingle2.kt
@@ -42,9 +42,9 @@ class ExportMissionPatrolSingle2(
     private val getComputeEnvMission: GetComputeEnvMission,
     private val computeAllOperationalSummary: ComputeAllOperationalSummary,
 
-    @Value("\${rapportnav.rapport-patrouille.template.path}") private val docTemplatePath: String,
-    @Value("\${rapportnav.rapport-patrouille.tmp_docx.path}") private val docTmpDOCXPath: String,
-    @Value("\${rapportnav.rapport-patrouille.tmp_odt.path}") private val docTmpODTPath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.template.path}") private val docTemplatePath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.tmp_docx.path}") private val docTmpDOCXPath: String,
+    @param:Value("\${rapportnav.rapport-patrouille.tmp_odt.path}") private val docTmpODTPath: String,
 ) {
 
     private val logger = LoggerFactory.getLogger(ExportMissionPatrolSingle2::class.java)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/infraction/GetNatinfs.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/infraction/GetNatinfs.kt
@@ -14,7 +14,7 @@ import java.net.http.HttpResponse
 @UseCase
 class GetNatinfs(
     private val mapper: ObjectMapper,
-    @Value("\${MONITORENV_HOST}") private val host: String,
+    @param:Value("\${MONITORENV_HOST}") private val host: String,
 ) {
 
     @Cacheable(value = ["natinfs"])

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/APIEnvMissionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/APIEnvMissionRepository.kt
@@ -28,7 +28,7 @@ import java.time.Instant
 class APIEnvMissionRepository(
     private val mapper: ObjectMapper,
     private val clientFactory: HttpClientFactory,
-    @Value("\${MONITORENV_HOST}") private val host: String,
+    @param:Value("\${MONITORENV_HOST}") private val host: String,
 ) : IEnvMissionRepository {
     private val logger: Logger = LoggerFactory.getLogger(APIEnvMissionRepository::class.java);
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/input/PatchMissionInput.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/input/PatchMissionInput.kt
@@ -9,10 +9,10 @@ import java.time.Instant
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PatchMissionInput @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
-    @JsonProperty("missionTypes") val missionTypes: List<MissionTypeEnum>? = null,
-    @JsonProperty("controlUnits") var controlUnits: List<LegacyControlUnitEntity>? = null,
-    @JsonProperty("startDateTimeUtc") val startDateTimeUtc: Instant? = null,
-    @JsonProperty("endDateTimeUtc") val endDateTimeUtc: Instant? = null,
-    @JsonProperty("isUnderJdp") val isUnderJdp: Boolean? = null,
-    @JsonProperty("observationsByUnit") val observationsByUnit: String? = null
+    @field:JsonProperty("missionTypes") val missionTypes: List<MissionTypeEnum>? = null,
+    @field:JsonProperty("controlUnits") var controlUnits: List<LegacyControlUnitEntity>? = null,
+    @field:JsonProperty("startDateTimeUtc") val startDateTimeUtc: Instant? = null,
+    @field:JsonProperty("endDateTimeUtc") val endDateTimeUtc: Instant? = null,
+    @field:JsonProperty("isUnderJdp") val isUnderJdp: Boolean? = null,
+    @field:JsonProperty("observationsByUnit") val observationsByUnit: String? = null
 )

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/output/MissionDataOutput.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/output/MissionDataOutput.kt
@@ -14,23 +14,23 @@ import java.time.ZonedDateTime
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class MissionDataOutput @JsonCreator(mode = JsonCreator.Mode.PROPERTIES) constructor(
-    @JsonProperty("id") val id: Int,
-    @JsonProperty("missionTypes") val missionTypes: List<MissionTypeEnum>,
-    @JsonProperty("controlUnits") val controlUnits: List<LegacyControlUnitEntity>? = listOf(),
-    @JsonProperty("openBy") val openBy: String? = null,
-    @JsonProperty("completedBy") val completedBy: String? = null,
-    @JsonProperty("observationsCacem") val observationsCacem: String? = null,
-    @JsonProperty("observationsCnsp") val observationsCnsp: String? = null,
-    @JsonProperty("facade") val facade: String? = null,
-    @JsonProperty("geom") val geom: MultiPolygon? = null,
-    @JsonProperty("startDateTimeUtc") val startDateTimeUtc: ZonedDateTime,
-    @JsonProperty("endDateTimeUtc") val endDateTimeUtc: ZonedDateTime? = null,
-    @JsonProperty("envActions") val envActions: List<EnvActionEntity>? = null,
-    @JsonProperty("missionSource") val missionSource: MissionSourceEnum,
-    @JsonProperty("hasMissionOrder") val hasMissionOrder: Boolean,
-    @JsonProperty("isUnderJdp") val isUnderJdp: Boolean,
-    @JsonProperty("isGeometryComputedFromControls") val isGeometryComputedFromControls: Boolean,
-    @JsonProperty("observationsByUnit") val observationsByUnit: String? = null
+    @field:JsonProperty("id") val id: Int,
+    @field:JsonProperty("missionTypes") val missionTypes: List<MissionTypeEnum>,
+    @field:JsonProperty("controlUnits") val controlUnits: List<LegacyControlUnitEntity>? = listOf(),
+    @field:JsonProperty("openBy") val openBy: String? = null,
+    @field:JsonProperty("completedBy") val completedBy: String? = null,
+    @field:JsonProperty("observationsCacem") val observationsCacem: String? = null,
+    @field:JsonProperty("observationsCnsp") val observationsCnsp: String? = null,
+    @field:JsonProperty("facade") val facade: String? = null,
+    @field:JsonProperty("geom") val geom: MultiPolygon? = null,
+    @field:JsonProperty("startDateTimeUtc") val startDateTimeUtc: ZonedDateTime,
+    @field:JsonProperty("endDateTimeUtc") val endDateTimeUtc: ZonedDateTime? = null,
+    @field:JsonProperty("envActions") val envActions: List<EnvActionEntity>? = null,
+    @field:JsonProperty("missionSource") val missionSource: MissionSourceEnum,
+    @field:JsonProperty("hasMissionOrder") val hasMissionOrder: Boolean,
+    @field:JsonProperty("isUnderJdp") val isUnderJdp: Boolean,
+    @field:JsonProperty("isGeometryComputedFromControls") val isGeometryComputedFromControls: Boolean,
+    @field:JsonProperty("observationsByUnit") val observationsByUnit: String? = null
 ) {
 
     fun toMissionEntity(): MissionEntity {

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvAdministrationRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvAdministrationRepository.kt
@@ -17,7 +17,7 @@ import java.net.http.HttpResponse
 class APIEnvAdministrationRepository(
     clientFactory: HttpClientFactory,
     private val mapper: ObjectMapper,
-    @Value("\${MONITORENV_HOST}") private val host: String,
+    @param:Value("\${MONITORENV_HOST}") private val host: String,
 ): IEnvAdministrationRepository {
 
     private val logger = LoggerFactory.getLogger(IEnvAdministrationRepository::class.java)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitRepository.kt
@@ -19,7 +19,7 @@ import java.net.http.HttpResponse
 class APIEnvControlUnitRepository(
     clientFactory: HttpClientFactory,
     private val mapper: ObjectMapper,
-    @Value("\${MONITORENV_HOST}") private val host: String,
+    @param:Value("\${MONITORENV_HOST}") private val host: String,
 ): IEnvControlUnitRepository {
 
     private val logger: Logger = LoggerFactory.getLogger(APIEnvControlUnitRepository::class.java);

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitResourceRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitResourceRepository.kt
@@ -17,7 +17,7 @@ import java.net.http.HttpResponse
 class APIEnvControlUnitResourceRepository(
     clientFactory: HttpClientFactory,
     private val mapper: ObjectMapper,
-    @Value("\${MONITORENV_HOST}") private val host: String,
+    @param:Value("\${MONITORENV_HOST}") private val host: String,
 ): IEnvControlUnitResourceRepository {
 
     private val logger = LoggerFactory.getLogger(APIEnvControlUnitResourceRepository::class.java)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvMissionRepositoryV2.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvMissionRepositoryV2.kt
@@ -22,7 +22,7 @@ import java.net.http.HttpResponse
 @Repository
 class APIEnvMissionRepositoryV2(
     clientFactory: HttpClientFactory,
-    @Value("\${MONITORENV_HOST}") private val host: String,
+    @param:Value("\${MONITORENV_HOST}") private val host: String,
     ): IEnvMissionRepository {
 
     private val logger: Logger = LoggerFactory.getLogger(APIEnvMissionRepositoryV2::class.java);

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorfish/APIFishActionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorfish/APIFishActionRepository.kt
@@ -24,8 +24,8 @@ import java.net.http.HttpResponse
 class APIFishActionRepository(
     private val mapper: ObjectMapper,
     private val clientFactory: HttpClientFactory,
-    @Value("\${MONITORFISH_HOST}") private val host: String,
-    @Value("\${MONITORFISH_API_KEY}") private var monitorFishApiKey: String,
+    @param:Value("\${MONITORFISH_HOST}") private val host: String,
+    @param:Value("\${MONITORFISH_API_KEY}") private var monitorFishApiKey: String,
 ) : IFishActionRepository {
     private val logger: Logger = LoggerFactory.getLogger(APIFishActionRepository::class.java)
 


### PR DESCRIPTION
J'ai enlevé pas mal de warnings du genre :
```
This annotation is currently applied to the value parameter only, but in the future it will also be applied to field. 
- To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments. 
- To keep applying to the value parameter only, use the '@param:' annotation target.
```