### PR TITLE
fix: redirect v1 to v2 component

### DIFF
--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -78,6 +78,16 @@ export const router = sentryCreateBrowserRouter([
     ),
     errorElement: <ErrorPage />
   },
+  // redirect non prefixed v2 page to v2 component
+  {
+    path: `/pam/missions`,
+    element: (
+      <AuthGuard>
+        <MissionListPamPage />
+      </AuthGuard>
+    ),
+    errorElement: <ErrorPage />
+  },
   {
     path: `${PAM_V2_HOME_PATH}/:missionId/:actionId?`,
     element: (


### PR DESCRIPTION
On a toujours des utilisateurs qui se connectent sur la `/pam/missions` donc en attendant qu'on refasse le routing frontend proprement, voila juste un petit patch