### PR TITLE
fix(offline): fix setting individual cache keys causing memory leaks

### DIFF
--- a/frontend/src/v2/features/common/services/__tests__/use-mission.test.tsx
+++ b/frontend/src/v2/features/common/services/__tests__/use-mission.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from '../../../../../query-client/axios'
+import { renderHook, waitFor } from '../../../../../test-utils.tsx'
+import useGetMissionQuery from '../use-mission.tsx'
+import { Mission2 } from '../../types/mission-types.ts'
+
+// --- MOCK axios.get to return mission list ---
+vi.mock('../../../../../query-client/axios', () => ({
+  default: {
+    get: vi.fn()
+  }
+}))
+
+describe('useMissionsQuery', () => {
+  let queryClient: QueryClient
+  let wrapper: React.FC<{ children: React.ReactNode }>
+  let setQueryDataSpy: vi.SpyInstance
+
+  beforeEach(() => {
+    // fresh QueryClient per test
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false
+        }
+      }
+    })
+
+    // Spy on queryClient.setQueryData
+    setQueryDataSpy = vi.spyOn(queryClient, 'setQueryData')
+
+    wrapper = ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+
+    // Reset mocks
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+    setQueryDataSpy.mockRestore()
+  })
+
+  it('fetches mission and populates each action in cache using setQueryData', async () => {
+    const mockMission: Mission2 = { id: 1, actions: [{ id: '11' }, { id: '12' }] }
+
+    ;(axios.get as vi.Mock).mockResolvedValue({ data: mockMission })
+
+    const { result } = renderHook(() => useGetMissionQuery('123'), { wrapper })
+
+    // Wait until the query is successful
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    // Should have called setQueryData for each mission
+    expect(setQueryDataSpy).toHaveBeenCalledTimes(2)
+
+    expect(setQueryDataSpy).toHaveBeenCalledWith(['actions', '11'], mockMission.actions[0])
+    expect(setQueryDataSpy).toHaveBeenCalledWith(['actions', '12'], mockMission.actions[1])
+  })
+
+  it('does not run query when missingId falsy', async () => {
+    ;(axios.get as vi.Mock).mockResolvedValue({ data: [] })
+    renderHook(() => useGetMissionQuery(undefined), { wrapper })
+
+    expect(axios.get).not.toHaveBeenCalled()
+    expect(setQueryDataSpy).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/v2/features/common/services/use-mission.tsx
+++ b/frontend/src/v2/features/common/services/use-mission.tsx
@@ -1,9 +1,10 @@
-import { skipToken, useQuery } from '@tanstack/react-query'
+import { skipToken, useQuery, useQueryClient } from '@tanstack/react-query'
 import { DYNAMIC_DATA_STALE_TIME } from '../../../../query-client'
 import axios from '../../../../query-client/axios'
 import { Mission2 } from '../types/mission-types'
-import { missionsKeys } from './query-keys.ts'
+import { actionsKeys, missionsKeys } from './query-keys.ts'
 import { useOnlineManager } from '../hooks/use-online-manager.tsx'
+import { MissionAction } from '../types/mission-action.ts'
 
 export const fetchMission = (missionId?: string): Promise<Mission2> =>
   axios.get(`missions/${missionId}`).then(response => {
@@ -11,18 +12,26 @@ export const fetchMission = (missionId?: string): Promise<Mission2> =>
   })
 
 const useGetMissionQuery = (missionId?: string) => {
+  const queryClient = useQueryClient()
   const { isOnline } = useOnlineManager()
 
-  const query = useQuery<Mission2>({
+  return useQuery<Mission2>({
     queryKey: missionsKeys.byId(missionId),
-    queryFn: missionId ? () => fetchMission(missionId) : skipToken,
+    queryFn: missionId
+      ? async () => {
+          const mission = await fetchMission(missionId)
+          // prefill individual cache keys
+          mission.actions?.forEach((action: MissionAction) => {
+            queryClient.setQueryData(actionsKeys.byId(action.id), action)
+          })
+          return mission
+        }
+      : skipToken,
     staleTime: DYNAMIC_DATA_STALE_TIME, // Cache data for 5 minutes
     retry: 2, // Retry failed requests twice before throwing an error
     refetchInterval: DYNAMIC_DATA_STALE_TIME,
     enabled: isOnline
   })
-
-  return query
 }
 
 export default useGetMissionQuery


### PR DESCRIPTION
Pour le offline, je dois remplir les cache-keys individuelles pour les missions et actions, histoire de pouvoir naviguer offline sauf que le useEffect était trop gourmand

https://tkdodo.eu/blog/seeding-the-query-cache#seeding-details-from-lists
Il propose deux méthodes. La pull strategies est trop chiante à cause du nom de nos cache-keys donc j'ai opté pour la push strategy et voyons voir si ca marche bien sur la durée