### PR TITLE
fix(security): harden logging config to prevent sensitive data exposure

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -30,18 +30,11 @@ server.compression.enabled=true
 server.compression.mime-types=text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json,application/xml,image/svg+xml
 ################
 ################
-# GraphQL API
-graphql.cors-enabled=true
-graphql.cors.allowed-origins=*
-graphql.cors.allowed-methods=GET, HEAD, POST
-spring.graphql.graphiql.enabled=true
-spring.graphql.graphiql.path=/graphiql
-################
-################
 # Logging
 logging.level.org.springframework.web=INFO
 logging.level.org.springframework.security=ERROR
 logging.level.org.springframework.security.web.FilterChainProxy=ERROR
+logging.level.org.hibernate.orm.connections.pooling=WARN
 ################
 ################
 # Sentry

--- a/infra/configurations/backend/application-int.properties
+++ b/infra/configurations/backend/application-int.properties
@@ -1,5 +1,16 @@
 # add special configuration for integration env here
 
+# Security hardening (slightly relaxed for debugging)
+spring.jpa.show-sql=false
+server.error.include-stacktrace=never
+server.servlet.request.logging.enabled=false
+
+# Flyway - exclude test data
+spring.flyway.locations=classpath:/db/migration
+
+# Logging - suppress sensitive info
+logging.level.org.hibernate.orm.connections.pooling=WARN
+
 # sentry
 sentry.enabled=${SENTRY_ENABLED:true}
 sentry.dsn=${SENTRY_DSN:}

--- a/infra/configurations/backend/application-prod.properties
+++ b/infra/configurations/backend/application-prod.properties
@@ -1,4 +1,16 @@
 # add special configuration for production env here
+
+# Security hardening
+spring.jpa.show-sql=false
+server.error.include-stacktrace=never
+server.servlet.request.logging.enabled=false
+
+# Flyway - exclude test data
+spring.flyway.locations=classpath:/db/migration
+
+# Logging - suppress sensitive info
+logging.level.org.hibernate.orm.connections.pooling=WARN
+
 # sentry
 sentry.enabled=${SENTRY_ENABLED:true}
 sentry.dsn=${SENTRY_DSN:}


### PR DESCRIPTION
- Suppress Hibernate connection pooling logs that exposed DB credentials
- Disable SQL query logging in int/prod environments
- Hide stack traces from HTTP error responses (still logged server-side)
- Disable request logging in int/prod
- Exclude test data from Flyway migrations in int/prod
- Remove GraphQL dev settings from base config