### PR TITLE
feat(User): add impersonation for admin users

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/config/CustomAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/config/CustomAuthenticationFilter.kt
@@ -1,10 +1,15 @@
 package fr.gouv.dgampa.rapportnav.config
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
@@ -13,10 +18,15 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class CustomAuthenticationFilter(
-    private val tokenService: TokenService
+    private val tokenService: TokenService,
+    private val processImpersonationRequest: ProcessImpersonationRequest
 ) : OncePerRequestFilter() {
 
     private val logger = LoggerFactory.getLogger(CustomAuthenticationFilter::class.java)
+
+    companion object {
+        const val IMPERSONATE_SERVICE_HEADER = "X-Impersonate-Service-Id"
+    }
 
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -27,25 +37,24 @@ class CustomAuthenticationFilter(
 
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             try {
-                // extract token
                 val token = authHeader.substring(7)
+                var user = tokenService.parseToken(token)
 
-                // through token, revalidate user with db data
-                // do not use token data directly
-                val user = tokenService.parseToken(token)
-
-                // set authorities from roles
-                val grantedAuthorities = user.roles.map { role ->
-                    SimpleGrantedAuthority("ROLE_$role")
-                }
-
-                // set user and authorities to secu context
-                val authentication = UsernamePasswordAuthenticationToken(
-                    user,
-                    "",
-                    grantedAuthorities
+                // Delegate impersonation to use case
+                val targetServiceId = request.getHeader(IMPERSONATE_SERVICE_HEADER)?.toIntOrNull()
+                user = processImpersonationRequest.execute(
+                    user = user,
+                    targetServiceId = targetServiceId,
+                    ipAddress = getClientIpAddress(request)
                 )
-                SecurityContextHolder.getContext().authentication = authentication
+
+                val authorities = user.roles.map { SimpleGrantedAuthority("ROLE_$it") }
+                SecurityContextHolder.getContext().authentication =
+                    UsernamePasswordAuthenticationToken(user, "", authorities)
+            } catch (e: BackendForbiddenException) {
+                logger.warn("Unauthorized impersonation attempt: ${e.message}")
+                sendForbiddenResponse(response, e.message ?: "Impersonation not authorized")
+                return
             } catch (e: Exception) {
                 logger.error("Error while authenticating user", e)
                 SecurityContextHolder.clearContext()
@@ -53,5 +62,22 @@ class CustomAuthenticationFilter(
         }
 
         filterChain.doFilter(request, response)
+    }
+
+    private fun sendForbiddenResponse(response: HttpServletResponse, message: String) {
+        response.status = HttpStatus.FORBIDDEN.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        val errorBody = mapOf("error" to "Forbidden", "message" to message)
+        response.writer.write(ObjectMapper().writeValueAsString(errorBody))
+        response.writer.flush()
+    }
+
+    private fun getClientIpAddress(request: HttpServletRequest): String? {
+        val xForwardedFor = request.getHeader("X-Forwarded-For")
+        return if (!xForwardedFor.isNullOrBlank()) {
+            xForwardedFor.split(",").firstOrNull()?.trim()
+        } else {
+            request.remoteAddr
+        }
     }
 }

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/user/ImpersonationContext.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/entities/user/ImpersonationContext.kt
@@ -1,0 +1,12 @@
+package fr.gouv.dgampa.rapportnav.domain.entities.user
+
+data class ImpersonationContext(
+    val isActive: Boolean = false,
+    val originalServiceId: Int? = null,
+    val impersonatedServiceId: Int? = null,
+    val impersonatedServiceName: String? = null
+) {
+    companion object {
+        val NONE = ImpersonationContext(isActive = false)
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendForbiddenErrorCode.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendForbiddenErrorCode.kt
@@ -1,0 +1,14 @@
+package fr.gouv.dgampa.rapportnav.domain.exceptions
+
+/**
+ * Error codes for forbidden (HTTP 403) operations.
+ *
+ * These errors occur when a user is authenticated but not authorized to perform
+ * the requested action.
+ *
+ * ### Important
+ * **Don't forget to mirror any update here in the corresponding Frontend enum.**
+ */
+enum class BackendForbiddenErrorCode {
+    UNAUTHORIZED_IMPERSONATION
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendForbiddenException.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendForbiddenException.kt
@@ -1,0 +1,20 @@
+package fr.gouv.dgampa.rapportnav.domain.exceptions
+
+/**
+ * Domain exception to throw when a user is authenticated but not authorized
+ * to perform the requested action.
+ *
+ * Returns HTTP 403 Forbidden.
+ *
+ * ## Examples
+ * - A non-admin user tries to impersonate another service.
+ * - A user tries to access a resource they don't have permission for.
+ *
+ * ## Logging
+ * This exception is logged as a warning on the Backend side for security monitoring.
+ */
+open class BackendForbiddenException(
+    val code: BackendForbiddenErrorCode,
+    final override val message: String? = null,
+    val data: Any? = null,
+) : RuntimeException(code.name)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendInternalErrorCode.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendInternalErrorCode.kt
@@ -1,0 +1,13 @@
+package fr.gouv.dgampa.rapportnav.domain.exceptions
+
+/**
+ * Error codes for internal server errors (HTTP 500).
+ *
+ * These errors occur when an unexpected internal failure happens in the backend.
+ *
+ * ### Important
+ * **Don't forget to mirror any update here in the corresponding Frontend enum.**
+ */
+enum class BackendInternalErrorCode {
+    AUDIT_LOGGING_FAILED
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendInternalException.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/exceptions/BackendInternalException.kt
@@ -8,11 +8,13 @@ import org.slf4j.LoggerFactory
  *
  * ## Examples
  * - An unexpected exception has been caught.
+ * - Audit logging failed.
  *
  * ## Logging
  * This exception is logged as an error on the Backend side.
  */
 open class BackendInternalException(
+    val code: BackendInternalErrorCode? = null,
     final override val message: String,
     val originalException: Exception? = null,
 ) : RuntimeException(message) {

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/repositories/user/ImpersonationContextHolder.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/repositories/user/ImpersonationContextHolder.kt
@@ -1,0 +1,15 @@
+package fr.gouv.dgampa.rapportnav.domain.repositories.user
+
+import fr.gouv.dgampa.rapportnav.domain.entities.user.ImpersonationContext
+
+/**
+ * Interface for holding impersonation context during a request.
+ * This allows the impersonation state to be accessed throughout the request lifecycle.
+ */
+interface ImpersonationContextHolder {
+    fun get(): ImpersonationContext
+    fun set(context: ImpersonationContext)
+    fun clear()
+    fun isImpersonating(): Boolean
+    fun getEffectiveServiceId(originalServiceId: Int?): Int?
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/CreateEnvMission.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/CreateEnvMission.kt
@@ -4,6 +4,7 @@ import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.MissionEnvEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.MissionSourceEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.controlResources.LegacyControlUnitEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionAEMSingle.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionAEMSingle.kt
@@ -4,6 +4,7 @@ import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.aem.AEMTableExport
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.export.MissionExportEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.GetComputeEnvActionListByMissionId
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.action.v2.GetComputeFishActionListByMissionId

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionPatrolSingle.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionPatrolSingle.kt
@@ -6,6 +6,7 @@ import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.export.MissionExpor
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.export.toMapForExport
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.v2.MissionGeneralInfoEntity2
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.analytics.ComputePatrolData
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetComputeEnvMission

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionReports.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/mission/export/ExportMissionReports.kt
@@ -4,6 +4,7 @@ import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.export.ExportModeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.export.ExportReportTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.export.MissionExportEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/LogImpersonationAudit.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/LogImpersonationAudit.kt
@@ -1,0 +1,47 @@
+package fr.gouv.dgampa.rapportnav.domain.use_cases.user
+
+import fr.gouv.dgampa.rapportnav.config.UseCase
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
+import fr.gouv.dgampa.rapportnav.infrastructure.database.model.user.ImpersonationAuditModel
+import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.interfaces.user.IDBImpersonationAuditRepository
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+/**
+ * Logs impersonation events for audit purposes.
+ * Throws exception on failure to ensure fail-closed behavior.
+ */
+@UseCase
+class LogImpersonationAudit(
+    private val repository: IDBImpersonationAuditRepository
+) {
+    private val logger = LoggerFactory.getLogger(LogImpersonationAudit::class.java)
+
+    /**
+     * Logs an impersonation audit entry.
+     * @throws BackendInternalException if the audit entry cannot be saved
+     */
+    fun execute(
+        adminUserId: Int,
+        targetServiceId: Int,
+        ipAddress: String?
+    ) {
+        try {
+            val audit = ImpersonationAuditModel(
+                adminUserId = adminUserId,
+                targetServiceId = targetServiceId,
+                ipAddress = ipAddress,
+                timestamp = Instant.now()
+            )
+            repository.save(audit)
+        } catch (e: Exception) {
+            logger.error("Failed to log impersonation audit: ${e.message}", e)
+            throw BackendInternalException(
+                code = BackendInternalErrorCode.AUDIT_LOGGING_FAILED,
+                message = "Cannot proceed with impersonation: audit logging failed",
+                originalException = e
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/ProcessImpersonationRequest.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/ProcessImpersonationRequest.kt
@@ -1,0 +1,92 @@
+package fr.gouv.dgampa.rapportnav.domain.use_cases.user
+
+import fr.gouv.dgampa.rapportnav.config.UseCase
+import fr.gouv.dgampa.rapportnav.domain.entities.user.ImpersonationContext
+import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
+import fr.gouv.dgampa.rapportnav.domain.entities.user.User
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenErrorCode
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenException
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
+import fr.gouv.dgampa.rapportnav.domain.repositories.user.ImpersonationContextHolder
+import org.slf4j.LoggerFactory
+
+/**
+ * Use case for processing impersonation requests.
+ * Validates the request, sets the impersonation context, and logs the audit entry.
+ */
+@UseCase
+class ProcessImpersonationRequest(
+    private val validateImpersonation: ValidateImpersonation,
+    private val logImpersonationAudit: LogImpersonationAudit,
+    private val impersonationContextHolder: ImpersonationContextHolder
+) {
+    private val logger = LoggerFactory.getLogger(ProcessImpersonationRequest::class.java)
+
+    /**
+     * Process an impersonation request.
+     *
+     * @param user The authenticated user making the request
+     * @param targetServiceId The service ID to impersonate (null if not impersonating)
+     * @param ipAddress The client IP address for audit logging
+     * @return The user, potentially with modified serviceId and reduced roles if impersonation is active
+     * @throws BackendForbiddenException if non-admin attempts to impersonate
+     */
+    fun execute(user: User, targetServiceId: Int?, ipAddress: String?): User {
+        if (targetServiceId == null) {
+            return user
+        }
+
+        // Only admins can impersonate - throw 403 for unauthorized attempts
+        if (!user.roles.contains(RoleTypeEnum.ADMIN)) {
+            logger.warn("Non-admin user ${user.id} attempted to impersonate service $targetServiceId")
+            throw BackendForbiddenException(
+                code = BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION,
+                message = "Impersonation requires ADMIN role"
+            )
+        }
+
+        return try {
+            val service = validateImpersonation.execute(user, targetServiceId)
+
+            // Audit log FIRST - fail-closed: if we can't audit, we can't impersonate
+            logImpersonationAudit.execute(
+                adminUserId = user.id ?: 0,
+                targetServiceId = targetServiceId,
+                ipAddress = ipAddress
+            )
+
+            // Set request-scoped context (available throughout request lifecycle)
+            impersonationContextHolder.set(
+                ImpersonationContext(
+                    isActive = true,
+                    originalServiceId = user.serviceId,
+                    impersonatedServiceId = targetServiceId,
+                    impersonatedServiceName = service.name
+                )
+            )
+
+            logger.info("Admin user ${user.id} impersonating service ${service.name} (id: $targetServiceId)")
+
+            // Return user with modified serviceId and ROLE_ADMIN removed
+            // This prevents accessing admin endpoints while impersonating
+            val impersonatedRoles = user.roles.filter { it != RoleTypeEnum.ADMIN }
+
+            user.copy(
+                serviceId = targetServiceId,
+                roles = impersonatedRoles
+            )
+        } catch (e: BackendInternalException) {
+            logger.error("Impersonation denied - audit logging failed for user ${user.id}: ${e.message}")
+            throw BackendForbiddenException(
+                code = BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION,
+                message = "Impersonation unavailable: audit system error"
+            )
+        } catch (e: IllegalArgumentException) {
+            logger.warn("Impersonation failed for user ${user.id}: ${e.message}")
+            throw BackendForbiddenException(
+                code = BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION,
+                message = "Invalid impersonation target"
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/ValidateImpersonation.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/ValidateImpersonation.kt
@@ -1,0 +1,43 @@
+package fr.gouv.dgampa.rapportnav.domain.use_cases.user
+
+import fr.gouv.dgampa.rapportnav.config.UseCase
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceEntity
+import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
+import fr.gouv.dgampa.rapportnav.domain.entities.user.User
+import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetServiceById
+
+/**
+ * Validates whether a user can impersonate a specific service.
+ * Only ADMIN users can impersonate, and the target service must exist and not be deleted.
+ */
+@UseCase
+class ValidateImpersonation(
+    private val getServiceById: GetServiceById
+) {
+    /**
+     * Validates that the user can impersonate the target service.
+     *
+     * @param user The user attempting to impersonate
+     * @param targetServiceId The service ID to impersonate
+     * @return The ServiceEntity if validation passes
+     * @throws IllegalArgumentException if user is not an admin
+     * @throws IllegalArgumentException if service does not exist or is deleted
+     */
+    fun execute(user: User, targetServiceId: Int): ServiceEntity {
+        // Check user has ADMIN role
+        if (!user.roles.contains(RoleTypeEnum.ADMIN)) {
+            throw IllegalArgumentException("Only ADMIN users can impersonate services")
+        }
+
+        // Check target service exists
+        val service = getServiceById.execute(targetServiceId)
+            ?: throw IllegalArgumentException("Service with id $targetServiceId does not exist")
+
+        // Check service is not deleted
+        if (service.deletedAt != null) {
+            throw IllegalArgumentException("Service with id $targetServiceId has been deleted")
+        }
+
+        return service
+    }
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/ControllersExceptionHandler.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/ControllersExceptionHandler.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.api
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException
 import fr.gouv.dgampa.rapportnav.infrastructure.api.adapters.ProblemDetailFactory
@@ -50,6 +51,16 @@ class ControllersExceptionHandler : ResponseEntityExceptionHandler() {
     fun handleBackendUsageException(e: BackendUsageException): ResponseEntity<ProblemDetail> {
         log.warn("Usage error: code=${e.code}, message=${e.message}")
         return respond(HttpStatus.BAD_REQUEST, ProblemDetailFactory.forUsageError(
+            code = e.code,
+            message = e.message,
+            data = e.data
+        ))
+    }
+
+    @ExceptionHandler(BackendForbiddenException::class)
+    fun handleBackendForbiddenException(e: BackendForbiddenException): ResponseEntity<ProblemDetail> {
+        logger.warn("Forbidden: code=${e.code}, message=${e.message}")
+        return respond(HttpStatus.FORBIDDEN, ProblemDetailFactory.forForbiddenError(
             code = e.code,
             message = e.message,
             data = e.data

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/adapters/ProblemDetailFactory.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/adapters/ProblemDetailFactory.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.api.adapters
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.infrastructure.exceptions.BackendRequestErrorCode
 import org.springframework.http.HttpStatus
@@ -34,6 +35,25 @@ object ProblemDetailFactory {
     ): ProblemDetail = buildWithCode(
         status = HttpStatus.BAD_REQUEST,
         category = "usage",
+        code = code.name,
+        title = code.toTitle(),
+        detail = message ?: code.defaultMessage(),
+        data = data
+    )
+
+    /**
+     * Creates a Problem Detail for forbidden errors (HTTP 403).
+     *
+     * Forbidden errors occur when a user is authenticated but not authorized
+     * to perform the requested action.
+     */
+    fun forForbiddenError(
+        code: BackendForbiddenErrorCode,
+        message: String? = null,
+        data: Any? = null
+    ): ProblemDetail = buildWithCode(
+        status = HttpStatus.FORBIDDEN,
+        category = "forbidden",
         code = code.name,
         title = code.toTitle(),
         detail = message ?: code.defaultMessage(),
@@ -189,4 +209,18 @@ fun BackendRequestErrorCode.toTitle(): String = when (this) {
  */
 fun BackendRequestErrorCode.defaultMessage(): String = when (this) {
     BackendRequestErrorCode.BODY_MISSING_DATA -> "The request body is missing required data"
+}
+
+/**
+ * Returns a human-readable title for the error code.
+ */
+fun BackendForbiddenErrorCode.toTitle(): String = when (this) {
+    BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION -> "Unauthorized Impersonation"
+}
+
+/**
+ * Returns a default message for the error code when no custom message is provided.
+ */
+fun BackendForbiddenErrorCode.defaultMessage(): String = when (this) {
+    BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION -> "You are not authorized to impersonate this service"
 }

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/admin/ServiceAdminController.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/admin/ServiceAdminController.kt
@@ -39,9 +39,16 @@ class ServiceAdminController(
             ApiResponse(responseCode = "404", description = "Did not find any services", content = [Content()])
         ]
     )
-    fun getServices(): List<Service?>? {
+    fun getServices(
+        @RequestParam(required = false) active: Boolean?
+    ): List<Service?>? {
         return try {
-            getServices.execute().map { Service.fromServiceEntity((it)) }
+            getServices.execute()
+                .let { services ->
+                    if (active == true) services.filter { it.deletedAt == null }
+                    else services
+                }
+                .map { Service.fromServiceEntity((it)) }
         } catch (e: Exception) {
             logger.error("ServiceRestController - failed to load services from MonitorEnv", e)
             throw Exception(e)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/admin/UserAdminController.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/admin/UserAdminController.kt
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v2/admin/users")
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
 class UserAdminController(
     private val updateUser: UpdateUser,
     private val disableUser: DisableUser,
@@ -58,7 +59,6 @@ class UserAdminController(
 
     @PostMapping("")
     @Operation(summary = "Create User")
-    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
     @ApiResponses(
         value = [
             ApiResponse(

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/context/RequestScopedImpersonationContextHolder.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/context/RequestScopedImpersonationContextHolder.kt
@@ -1,0 +1,31 @@
+package fr.gouv.dgampa.rapportnav.infrastructure.context
+
+import fr.gouv.dgampa.rapportnav.domain.entities.user.ImpersonationContext
+import fr.gouv.dgampa.rapportnav.domain.repositories.user.ImpersonationContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.context.annotation.RequestScope
+
+/**
+ * Request-scoped implementation of ImpersonationContextHolder.
+ * Each HTTP request gets its own instance, ensuring isolation between requests.
+ */
+@Component
+@RequestScope
+class RequestScopedImpersonationContextHolder : ImpersonationContextHolder {
+    private var context: ImpersonationContext = ImpersonationContext.NONE
+
+    override fun get(): ImpersonationContext = context
+
+    override fun set(context: ImpersonationContext) {
+        this.context = context
+    }
+
+    override fun clear() {
+        context = ImpersonationContext.NONE
+    }
+
+    override fun isImpersonating(): Boolean = context.isActive
+
+    override fun getEffectiveServiceId(originalServiceId: Int?): Int? =
+        if (context.isActive) context.impersonatedServiceId else originalServiceId
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/model/user/ImpersonationAuditModel.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/model/user/ImpersonationAuditModel.kt
@@ -1,0 +1,36 @@
+package fr.gouv.dgampa.rapportnav.infrastructure.database.model.user
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "impersonation_audit",
+    indexes = [
+        Index(name = "idx_impersonation_audit_admin_user_id", columnList = "admin_user_id"),
+        Index(name = "idx_impersonation_audit_timestamp", columnList = "timestamp")
+    ]
+)
+data class ImpersonationAuditModel(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Int? = null,
+
+    @Column(name = "admin_user_id", nullable = false)
+    val adminUserId: Int,
+
+    @Column(name = "target_service_id", nullable = false)
+    val targetServiceId: Int,
+
+    @Column(name = "ip_address", length = 45)
+    val ipAddress: String?,
+
+    @Column(nullable = false)
+    val timestamp: Instant = Instant.now()
+)

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/interfaces/user/IDBImpersonationAuditRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/interfaces/user/IDBImpersonationAuditRepository.kt
@@ -1,0 +1,10 @@
+package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.interfaces.user
+
+import fr.gouv.dgampa.rapportnav.infrastructure.database.model.user.ImpersonationAuditModel
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.Instant
+
+interface IDBImpersonationAuditRepository : JpaRepository<ImpersonationAuditModel, Int> {
+    fun findByAdminUserIdAndTimestampAfter(adminUserId: Int, after: Instant): List<ImpersonationAuditModel>
+    fun findByTargetServiceIdAndTimestampAfter(serviceId: Int, after: Instant): List<ImpersonationAuditModel>
+}

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/JPAMissionNavRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/JPAMissionNavRepository.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/action/JPAMissionActionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/action/JPAMissionActionRepository.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.action
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAAgentRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAAgentRepository.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAAgentRoleRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAAgentRoleRepository.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAMissionCrewRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAMissionCrewRepository.kt
@@ -1,6 +1,7 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.MissionCrewEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAMissionPassengerRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAMissionPassengerRepository.kt
@@ -1,6 +1,7 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.MissionPassengerEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAServiceRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/crew/JPAServiceRepository.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.crew
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/generalInfo/JPAMissionGeneralInfoRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/generalInfo/JPAMissionGeneralInfoRepository.kt
@@ -1,6 +1,7 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.generalInfo
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.generalInfo.MissionGeneralInfoEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPAInquiryRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPAInquiryRepository.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.target2.v2
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPATargetRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPATargetRepository.kt
@@ -1,5 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.mission.target2.v2
 
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvAdministrationRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvAdministrationRepository.kt
@@ -1,6 +1,7 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.monitorenv.v2
 
 import fr.gouv.dgampa.rapportnav.config.HttpClientFactory
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.repositories.v2.IEnvAdministrationRepository
 import fr.gouv.dgampa.rapportnav.infrastructure.monitorenv.v2.outputs.FullAdministrationDataOutput

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitResourceRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvControlUnitResourceRepository.kt
@@ -1,6 +1,7 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.monitorenv.v2
 
 import fr.gouv.dgampa.rapportnav.config.HttpClientFactory
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.repositories.v2.controlUnitResource.IEnvControlUnitResourceRepository
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2.env.ControlUnitResourceEnv

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvMissionRepositoryV2.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvMissionRepositoryV2.kt
@@ -3,6 +3,7 @@ package fr.gouv.dgampa.rapportnav.infrastructure.monitorenv.v2
 import fr.gouv.dgampa.rapportnav.config.HttpClientFactory
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.MissionEnvEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.env.MissionSourceEnum
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.repositories.v2.mission.IEnvMissionRepository
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2.MissionEnv

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvNatinfRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorenv/v2/APIEnvNatinfRepository.kt
@@ -2,6 +2,7 @@ package fr.gouv.dgampa.rapportnav.infrastructure.monitorenv.v2
 
 import fr.gouv.dgampa.rapportnav.config.HttpClientFactory
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.infraction.NatinfEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.repositories.mission.infraction.INatinfRepository
 import org.slf4j.LoggerFactory

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorfish/APIFishActionRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/monitorfish/APIFishActionRepository.kt
@@ -5,6 +5,7 @@ import fr.gouv.dgampa.rapportnav.config.HttpClientFactory
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.fish.fishActions.MissionAction
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.repositories.mission.IFishActionRepository
 import fr.gouv.dgampa.rapportnav.infrastructure.monitorfish.input.PatchActionInput

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/utils/ZipUtils.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/utils/ZipUtils.kt
@@ -1,6 +1,7 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.utils
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.export.MissionExportEntity
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/main/resources/db/migration/V1.2026.02.23.10.00__add_impersonation_audit.sql
+++ b/backend/src/main/resources/db/migration/V1.2026.02.23.10.00__add_impersonation_audit.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS impersonation_audit (
+    id SERIAL PRIMARY KEY,
+    admin_user_id INTEGER NOT NULL,
+    target_service_id INTEGER NOT NULL,
+    ip_address VARCHAR(45),
+    timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_impersonation_audit_admin_user_id ON impersonation_audit(admin_user_id);
+CREATE INDEX IF NOT EXISTS idx_impersonation_audit_timestamp ON impersonation_audit(timestamp);

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/CustomAuthenticationFilterTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/CustomAuthenticationFilterTest.kt
@@ -3,20 +3,29 @@ package fr.gouv.gmampa.rapportnav.config
 import fr.gouv.dgampa.rapportnav.config.CustomAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenErrorCode
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import jakarta.servlet.FilterChain
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
 
 class CustomAuthenticationFilterTest {
     private lateinit var tokenService: TokenService
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
     private lateinit var filter: CustomAuthenticationFilter
     private lateinit var request: MockHttpServletRequest
     private lateinit var response: MockHttpServletResponse
@@ -25,7 +34,8 @@ class CustomAuthenticationFilterTest {
     @BeforeEach
     fun setUp() {
         tokenService = mock()
-        filter = CustomAuthenticationFilter(tokenService)
+        processImpersonationRequest = mock()
+        filter = CustomAuthenticationFilter(tokenService, processImpersonationRequest)
         request = MockHttpServletRequest()
         response = MockHttpServletResponse()
         filterChain = mock()
@@ -45,6 +55,7 @@ class CustomAuthenticationFilterTest {
 
         request.addHeader("Authorization", "Bearer valid-token")
         whenever(tokenService.parseToken("valid-token")).thenReturn(user)
+        whenever(processImpersonationRequest.execute(eq(user), anyOrNull(), anyOrNull())).thenReturn(user)
 
         filter.doFilter(request, response, filterChain)
 
@@ -68,6 +79,7 @@ class CustomAuthenticationFilterTest {
 
         request.addHeader("Authorization", "Bearer valid-token")
         whenever(tokenService.parseToken("valid-token")).thenReturn(user)
+        whenever(processImpersonationRequest.execute(eq(user), anyOrNull(), anyOrNull())).thenReturn(user)
 
         filter.doFilter(request, response, filterChain)
 
@@ -136,11 +148,140 @@ class CustomAuthenticationFilterTest {
 
         request.addHeader("Authorization", "Bearer my-special-token-123")
         whenever(tokenService.parseToken("my-special-token-123")).thenReturn(user)
+        whenever(processImpersonationRequest.execute(eq(user), anyOrNull(), anyOrNull())).thenReturn(user)
 
         filter.doFilter(request, response, filterChain)
 
         val auth = SecurityContextHolder.getContext().authentication
         assertNotNull(auth)
         verify(tokenService).parseToken("my-special-token-123")
+    }
+
+    @Test
+    fun `should delegate impersonation to ProcessImpersonationRequest use case`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        // When impersonating, ROLE_ADMIN should be removed
+        val impersonatedUser = adminUser.copy(serviceId = 200, roles = listOf(RoleTypeEnum.USER_PAM))
+
+        request.addHeader("Authorization", "Bearer valid-token")
+        request.addHeader("X-Impersonate-Service-Id", "200")
+        whenever(tokenService.parseToken("valid-token")).thenReturn(adminUser)
+        whenever(processImpersonationRequest.execute(eq(adminUser), eq(200), anyOrNull()))
+            .thenReturn(impersonatedUser)
+
+        filter.doFilter(request, response, filterChain)
+
+        val auth = SecurityContextHolder.getContext().authentication
+        assertNotNull(auth)
+        val principal = auth?.principal as User
+        assertEquals(200, principal.serviceId)
+        // Should not have ROLE_ADMIN anymore
+        assertFalse(auth.authorities.any { it.authority == "ROLE_ADMIN" })
+        verify(processImpersonationRequest).execute(eq(adminUser), eq(200), anyOrNull())
+        verify(filterChain).doFilter(request, response)
+    }
+
+    @Test
+    fun `should return 403 when non-admin attempts impersonation`() {
+        val regularUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "User",
+            lastName = "Test",
+            email = "user@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.USER_PAM)
+        )
+
+        request.addHeader("Authorization", "Bearer valid-token")
+        request.addHeader("X-Impersonate-Service-Id", "200")
+        whenever(tokenService.parseToken("valid-token")).thenReturn(regularUser)
+        whenever(processImpersonationRequest.execute(eq(regularUser), eq(200), anyOrNull()))
+            .thenThrow(BackendForbiddenException(BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION, "Impersonation requires ADMIN role"))
+
+        filter.doFilter(request, response, filterChain)
+
+        assertEquals(HttpStatus.FORBIDDEN.value(), response.status)
+        assertTrue(response.contentAsString.contains("Forbidden"))
+        // Filter chain should NOT be called when returning 403
+        verify(filterChain, never()).doFilter(any(), any())
+    }
+
+    @Test
+    fun `should return 403 when impersonation validation fails`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+
+        request.addHeader("Authorization", "Bearer valid-token")
+        request.addHeader("X-Impersonate-Service-Id", "999")
+        whenever(tokenService.parseToken("valid-token")).thenReturn(adminUser)
+        whenever(processImpersonationRequest.execute(eq(adminUser), eq(999), anyOrNull()))
+            .thenThrow(BackendForbiddenException(BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION, "Invalid impersonation target: Service not found"))
+
+        filter.doFilter(request, response, filterChain)
+
+        assertEquals(HttpStatus.FORBIDDEN.value(), response.status)
+        assertTrue(response.contentAsString.contains("Forbidden"))
+        verify(filterChain, never()).doFilter(any(), any())
+    }
+
+    @Test
+    fun `should pass null targetServiceId when header is missing`() {
+        val user = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "User",
+            lastName = "Test",
+            email = "user@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.USER_PAM)
+        )
+
+        request.addHeader("Authorization", "Bearer valid-token")
+        whenever(tokenService.parseToken("valid-token")).thenReturn(user)
+        whenever(processImpersonationRequest.execute(eq(user), eq(null), anyOrNull())).thenReturn(user)
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(processImpersonationRequest).execute(eq(user), eq(null), anyOrNull())
+        verify(filterChain).doFilter(request, response)
+    }
+
+    @Test
+    fun `should pass null targetServiceId when header is not a valid integer`() {
+        val user = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+
+        request.addHeader("Authorization", "Bearer valid-token")
+        request.addHeader("X-Impersonate-Service-Id", "invalid")
+        whenever(tokenService.parseToken("valid-token")).thenReturn(user)
+        whenever(processImpersonationRequest.execute(eq(user), eq(null), anyOrNull())).thenReturn(user)
+
+        filter.doFilter(request, response, filterChain)
+
+        verify(processImpersonationRequest).execute(eq(user), eq(null), anyOrNull())
+        verify(filterChain).doFilter(request, response)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/user/ProcessImpersonationRequestTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/user/ProcessImpersonationRequestTest.kt
@@ -1,0 +1,314 @@
+package fr.gouv.gmampa.rapportnav.domain.use_cases.user
+
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceEntity
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceTypeEnum
+import fr.gouv.dgampa.rapportnav.domain.entities.user.ImpersonationContext
+import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
+import fr.gouv.dgampa.rapportnav.domain.entities.user.User
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenErrorCode
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendForbiddenException
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalErrorCode
+import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
+import fr.gouv.dgampa.rapportnav.domain.repositories.user.ImpersonationContextHolder
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.LogImpersonationAudit
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ValidateImpersonation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ProcessImpersonationRequestTest {
+
+    private lateinit var validateImpersonation: ValidateImpersonation
+    private lateinit var logImpersonationAudit: LogImpersonationAudit
+    private lateinit var impersonationContextHolder: ImpersonationContextHolder
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
+
+    @BeforeEach
+    fun setUp() {
+        validateImpersonation = mock()
+        logImpersonationAudit = mock()
+        impersonationContextHolder = mock()
+        processImpersonationRequest = ProcessImpersonationRequest(
+            validateImpersonation,
+            logImpersonationAudit,
+            impersonationContextHolder
+        )
+    }
+
+    @Test
+    fun `should return original user when targetServiceId is null`() {
+        val user = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Test",
+            lastName = "User",
+            email = "test@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.USER_PAM)
+        )
+
+        val result = processImpersonationRequest.execute(user, null, "127.0.0.1")
+
+        assertThat(result).isEqualTo(user)
+        verify(validateImpersonation, never()).execute(any(), any())
+        verify(logImpersonationAudit, never()).execute(any(), any(), any())
+        verify(impersonationContextHolder, never()).set(any())
+    }
+
+    @Test
+    fun `should throw BackendForbiddenException when user is not admin`() {
+        val regularUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Regular",
+            lastName = "User",
+            email = "user@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.USER_PAM)
+        )
+
+        val exception = assertThrows<BackendForbiddenException> {
+            processImpersonationRequest.execute(regularUser, 200, "127.0.0.1")
+        }
+
+        assertThat(exception.code).isEqualTo(BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION)
+        assertThat(exception.message).isEqualTo("Impersonation requires ADMIN role")
+        verify(validateImpersonation, never()).execute(any(), any())
+        verify(logImpersonationAudit, never()).execute(any(), any(), any())
+        verify(impersonationContextHolder, never()).set(any())
+    }
+
+    @Test
+    fun `should impersonate service for admin user`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 200)).thenReturn(targetService)
+
+        val result = processImpersonationRequest.execute(adminUser, 200, "127.0.0.1")
+
+        assertThat(result.serviceId).isEqualTo(200)
+        assertThat(result.id).isEqualTo(adminUser.id)
+        assertThat(result.email).isEqualTo(adminUser.email)
+    }
+
+    @Test
+    fun `should remove ROLE_ADMIN from roles when impersonating`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN, RoleTypeEnum.USER_PAM)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 200)).thenReturn(targetService)
+
+        val result = processImpersonationRequest.execute(adminUser, 200, "127.0.0.1")
+
+        assertThat(result.roles).doesNotContain(RoleTypeEnum.ADMIN)
+        assertThat(result.roles).containsExactly(RoleTypeEnum.USER_PAM)
+    }
+
+    @Test
+    fun `should set impersonation context when impersonating`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 200)).thenReturn(targetService)
+
+        processImpersonationRequest.execute(adminUser, 200, "127.0.0.1")
+
+        val contextCaptor = argumentCaptor<ImpersonationContext>()
+        verify(impersonationContextHolder).set(contextCaptor.capture())
+
+        val capturedContext = contextCaptor.firstValue
+        assertThat(capturedContext.isActive).isTrue()
+        assertThat(capturedContext.originalServiceId).isEqualTo(100)
+        assertThat(capturedContext.impersonatedServiceId).isEqualTo(200)
+        assertThat(capturedContext.impersonatedServiceName).isEqualTo("Target Service")
+    }
+
+    @Test
+    fun `should log audit entry when impersonating`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 200)).thenReturn(targetService)
+
+        processImpersonationRequest.execute(adminUser, 200, "192.168.1.1")
+
+        verify(logImpersonationAudit).execute(
+            adminUserId = 1,
+            targetServiceId = 200,
+            ipAddress = "192.168.1.1"
+        )
+    }
+
+    @Test
+    fun `should throw BackendForbiddenException when validation fails`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 999))
+            .thenThrow(IllegalArgumentException("Service not found"))
+
+        val exception = assertThrows<BackendForbiddenException> {
+            processImpersonationRequest.execute(adminUser, 999, "127.0.0.1")
+        }
+
+        assertThat(exception.code).isEqualTo(BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION)
+        assertThat(exception.message).contains("Invalid impersonation target")
+        verify(logImpersonationAudit, never()).execute(any(), any(), any())
+        verify(impersonationContextHolder, never()).set(any())
+    }
+
+    @Test
+    fun `should handle null user id when logging audit`() {
+        val adminUser = User(
+            id = null,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 200)).thenReturn(targetService)
+
+        processImpersonationRequest.execute(adminUser, 200, "127.0.0.1")
+
+        verify(logImpersonationAudit).execute(
+            adminUserId = 0,
+            targetServiceId = 200,
+            ipAddress = "127.0.0.1"
+        )
+    }
+
+    @Test
+    fun `should preserve non-admin user properties when impersonating`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN, RoleTypeEnum.USER_PAM, RoleTypeEnum.USER_ULAM)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 200)).thenReturn(targetService)
+
+        val result = processImpersonationRequest.execute(adminUser, 200, "127.0.0.1")
+
+        assertThat(result.id).isEqualTo(1)
+        assertThat(result.firstName).isEqualTo("Admin")
+        assertThat(result.lastName).isEqualTo("User")
+        assertThat(result.email).isEqualTo("admin@test.com")
+        assertThat(result.password).isEqualTo("password")
+        assertThat(result.serviceId).isEqualTo(200)
+        // ROLE_ADMIN should be removed, but other roles preserved
+        assertThat(result.roles).containsExactlyInAnyOrder(RoleTypeEnum.USER_PAM, RoleTypeEnum.USER_ULAM)
+        assertThat(result.roles).doesNotContain(RoleTypeEnum.ADMIN)
+    }
+
+    @Test
+    fun `should throw BackendForbiddenException when audit logging fails (fail-closed)`() {
+        val adminUser = User(
+            id = 1,
+            serviceId = 100,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        whenever(validateImpersonation.execute(adminUser, 200)).thenReturn(targetService)
+        whenever(logImpersonationAudit.execute(any(), any(), any()))
+            .thenThrow(BackendInternalException(BackendInternalErrorCode.AUDIT_LOGGING_FAILED, "Database connection failed"))
+
+        val exception = assertThrows<BackendForbiddenException> {
+            processImpersonationRequest.execute(adminUser, 200, "127.0.0.1")
+        }
+
+        assertThat(exception.code).isEqualTo(BackendForbiddenErrorCode.UNAUTHORIZED_IMPERSONATION)
+        assertThat(exception.message).contains("audit system error")
+        // Context should NOT be set if audit fails
+        verify(impersonationContextHolder, never()).set(any())
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/user/ValidateImpersonationTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/user/ValidateImpersonationTest.kt
@@ -1,0 +1,117 @@
+package fr.gouv.gmampa.rapportnav.domain.use_cases.user
+
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceEntity
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceTypeEnum
+import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
+import fr.gouv.dgampa.rapportnav.domain.entities.user.User
+import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetServiceById
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ValidateImpersonation
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.time.Instant
+
+@SpringBootTest(classes = [ValidateImpersonation::class])
+@ContextConfiguration(classes = [ValidateImpersonation::class])
+class ValidateImpersonationTest {
+
+    @Autowired
+    private lateinit var validateImpersonation: ValidateImpersonation
+
+    @MockitoBean
+    private lateinit var getServiceById: GetServiceById
+
+    @Test
+    fun `should return service when admin impersonates valid active service`() {
+        val adminUser = User(
+            id = 1,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        val targetService = ServiceEntity(
+            id = 200,
+            name = "Target Service",
+            serviceType = ServiceTypeEnum.PAM
+        )
+
+        `when`(getServiceById.execute(200)).thenReturn(targetService)
+
+        val result = validateImpersonation.execute(adminUser, 200)
+
+        assertThat(result).isNotNull
+        assertThat(result.id).isEqualTo(200)
+        assertThat(result.name).isEqualTo("Target Service")
+    }
+
+    @Test
+    fun `should throw exception when non-admin tries to impersonate`() {
+        val regularUser = User(
+            id = 1,
+            firstName = "Regular",
+            lastName = "User",
+            email = "user@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.USER_PAM)
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            validateImpersonation.execute(regularUser, 200)
+        }
+
+        assertThat(exception.message).isEqualTo("Only ADMIN users can impersonate services")
+    }
+
+    @Test
+    fun `should throw exception when service does not exist`() {
+        val adminUser = User(
+            id = 1,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+
+        `when`(getServiceById.execute(999)).thenReturn(null)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            validateImpersonation.execute(adminUser, 999)
+        }
+
+        assertThat(exception.message).isEqualTo("Service with id 999 does not exist")
+    }
+
+    @Test
+    fun `should throw exception when service is deleted`() {
+        val adminUser = User(
+            id = 1,
+            firstName = "Admin",
+            lastName = "User",
+            email = "admin@test.com",
+            password = "password",
+            roles = listOf(RoleTypeEnum.ADMIN)
+        )
+        val deletedService = ServiceEntity(
+            id = 200,
+            name = "Deleted Service",
+            serviceType = ServiceTypeEnum.PAM,
+            deletedAt = Instant.now()
+        )
+
+        `when`(getServiceById.execute(200)).thenReturn(deletedService)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            validateImpersonation.execute(adminUser, 200)
+        }
+
+        assertThat(exception.message).isEqualTo("Service with id 200 has been deleted")
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/ServiceAdminControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/ServiceAdminControllerTest.kt
@@ -1,0 +1,130 @@
+package fr.gouv.gmampa.rapportnav.infrastructure.api.admin
+
+import fr.gouv.dgampa.rapportnav.RapportNavApplication
+import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceTypeEnum
+import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
+import fr.gouv.dgampa.rapportnav.domain.use_cases.service.CreateOrUpdateService
+import fr.gouv.dgampa.rapportnav.domain.use_cases.service.DeleteService
+import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetServiceById
+import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetServices
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
+import fr.gouv.dgampa.rapportnav.infrastructure.api.admin.ServiceAdminController
+import fr.gouv.gmampa.rapportnav.mocks.mission.crew.ServiceEntityMock
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.Instant
+
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = [RapportNavApplication::class])
+@WebMvcTest(ServiceAdminController::class)
+@ImportAutoConfiguration(CacheAutoConfiguration::class)
+class ServiceAdminControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockitoBean
+    private lateinit var getServices: GetServices
+
+    @MockitoBean
+    private lateinit var deleteService: DeleteService
+
+    @MockitoBean
+    private lateinit var getServiceById: GetServiceById
+
+    @MockitoBean
+    private lateinit var createOrUpdateService: CreateOrUpdateService
+
+    @MockitoBean
+    private lateinit var tokenService: TokenService
+
+    @MockitoBean
+    private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
+
+    @Test
+    fun `getServices should return all services when active param not provided`() {
+        val services = listOf(
+            ServiceEntityMock.create(id = 1, name = "Service 1", serviceType = ServiceTypeEnum.PAM),
+            ServiceEntityMock.create(id = 2, name = "Service 2", serviceType = ServiceTypeEnum.ULAM, deletedAt = Instant.now())
+        )
+
+        `when`(getServices.execute()).thenReturn(services)
+
+        mockMvc.perform(get("/api/v2/admin/services"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$").isArray)
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[0].id").value(1))
+            .andExpect(jsonPath("$[0].name").value("Service 1"))
+            .andExpect(jsonPath("$[1].id").value(2))
+            .andExpect(jsonPath("$[1].name").value("Service 2"))
+    }
+
+    @Test
+    fun `getServices should return only active services when active=true`() {
+        val activeService = ServiceEntityMock.create(id = 1, name = "Active Service", serviceType = ServiceTypeEnum.PAM)
+        val deletedService = ServiceEntityMock.create(id = 2, name = "Deleted Service", serviceType = ServiceTypeEnum.ULAM, deletedAt = Instant.now())
+        val services = listOf(activeService, deletedService)
+
+        `when`(getServices.execute()).thenReturn(services)
+
+        mockMvc.perform(get("/api/v2/admin/services").param("active", "true"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$").isArray)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value(1))
+            .andExpect(jsonPath("$[0].name").value("Active Service"))
+    }
+
+    @Test
+    fun `getServices should return all services when active=false`() {
+        val activeService = ServiceEntityMock.create(id = 1, name = "Active Service", serviceType = ServiceTypeEnum.PAM)
+        val deletedService = ServiceEntityMock.create(id = 2, name = "Deleted Service", serviceType = ServiceTypeEnum.ULAM, deletedAt = Instant.now())
+        val services = listOf(activeService, deletedService)
+
+        `when`(getServices.execute()).thenReturn(services)
+
+        mockMvc.perform(get("/api/v2/admin/services").param("active", "false"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$").isArray)
+            .andExpect(jsonPath("$.length()").value(2))
+    }
+
+    @Test
+    fun `getServices should return empty list when no active services and active=true`() {
+        val deletedService = ServiceEntityMock.create(id = 1, name = "Deleted Service", serviceType = ServiceTypeEnum.PAM, deletedAt = Instant.now())
+        val services = listOf(deletedService)
+
+        `when`(getServices.execute()).thenReturn(services)
+
+        mockMvc.perform(get("/api/v2/admin/services").param("active", "true"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$").isArray)
+            .andExpect(jsonPath("$.length()").value(0))
+    }
+
+    @Test
+    fun `getServices should return empty list when no services`() {
+        `when`(getServices.execute()).thenReturn(emptyList())
+
+        mockMvc.perform(get("/api/v2/admin/services"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$").isArray)
+            .andExpect(jsonPath("$.length()").value(0))
+    }
+}

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/UserAdminControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/UserAdminControllerTest.kt
@@ -4,6 +4,7 @@ import fr.gouv.dgampa.rapportnav.RapportNavApplication
 import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.GetAuthenticationAuditList
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.*
 import fr.gouv.dgampa.rapportnav.infrastructure.api.admin.UserAdminController
 import fr.gouv.gmampa.rapportnav.mocks.user.UserMock
@@ -63,6 +64,9 @@ class UserAdminControllerTest {
 
     @MockitoBean
     private lateinit var getAuthenticationAuditList: GetAuthenticationAuditList
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     private val jsonMapper = JsonMapper.builder().build()
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AdministrationControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AdministrationControllerTest.kt
@@ -4,6 +4,7 @@ import fr.gouv.dgampa.rapportnav.RapportNavApplication
 import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.administrations.GetAdministrationById
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.administrations.GetAdministrations
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.model.v2.env.FullAdministration
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.AdministrationController
@@ -41,6 +42,9 @@ class AdministrationControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `getAll should return list of administrations`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRestControllerTest.kt
@@ -5,6 +5,7 @@ import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.AgentEntity
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetCrewByServiceId
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.GetUserFromToken
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.AgentRestController
 import fr.gouv.gmampa.rapportnav.mocks.mission.crew.ServiceEntityMock
@@ -43,6 +44,9 @@ class AgentRestControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `agents should return list of agents for user's service`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRoleControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRoleControllerTest.kt
@@ -5,6 +5,7 @@ import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.AgentRoleEntity
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetAgentRoles
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.AgentRoleController
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
@@ -37,6 +38,9 @@ class AgentRoleControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `agentRoles should return list of roles`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/ControlUnitResourceRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/ControlUnitResourceRestControllerTest.kt
@@ -5,6 +5,7 @@ import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.controlUnitResource.GetControlUnitResources
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.ControlUnitResourceRestController
 import fr.gouv.gmampa.rapportnav.mocks.mission.env.ControlUnitResourceEnvMock
 import org.junit.jupiter.api.Test
@@ -38,6 +39,9 @@ class ControlUnitResourceRestControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `getAll should return list of control unit resources`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/CrewRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/CrewRestControllerTest.kt
@@ -6,6 +6,7 @@ import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.AgentEntity
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetCrewByServiceId
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetServices
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.CrewRestController
 import fr.gouv.gmampa.rapportnav.mocks.mission.crew.ServiceEntityMock
@@ -43,6 +44,9 @@ class CrewRestControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `getAllCrews should return list of services with agents`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/MissionRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/MissionRestControllerTest.kt
@@ -7,6 +7,7 @@ import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.*
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.GetServiceForUser
 import fr.gouv.dgampa.rapportnav.infrastructure.api.ControllersExceptionHandler
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.MissionRestController
@@ -71,6 +72,9 @@ class MissionRestControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     /**
      *

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/NatInfRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/NatInfRestControllerTest.kt
@@ -6,6 +6,7 @@ import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.infraction.NatinfEn
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.infraction.GetNatinfs
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.NatInfRestController
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
@@ -38,6 +39,9 @@ class NatInfRestControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `getNatinfs should return list of natinfs`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/UserRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/UserRestControllerTest.kt
@@ -4,6 +4,7 @@ import fr.gouv.dgampa.rapportnav.RapportNavApplication
 import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetServiceById
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.FindById
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.UserRestController
 import fr.gouv.gmampa.rapportnav.mocks.mission.crew.ServiceEntityMock
@@ -43,6 +44,9 @@ class UserRestControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `getUserById should return user info when user exists`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/VesselRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/VesselRestControllerTest.kt
@@ -5,6 +5,7 @@ import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetVessels
+import fr.gouv.dgampa.rapportnav.domain.use_cases.user.ProcessImpersonationRequest
 import fr.gouv.dgampa.rapportnav.infrastructure.api.bff.v2.VesselRestController
 import fr.gouv.gmampa.rapportnav.mocks.mission.VesselEntityMock
 import org.junit.jupiter.api.Test
@@ -38,6 +39,9 @@ class VesselRestControllerTest {
 
     @MockitoBean
     private lateinit var apiKeyAuthenticationFilter: ApiKeyAuthenticationFilter
+
+    @MockitoBean
+    private lateinit var processImpersonationRequest: ProcessImpersonationRequest
 
     @Test
     fun `getVessels should return filtered list of vessels`() {

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/mocks/mission/crew/ServiceEntityMock.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/mocks/mission/crew/ServiceEntityMock.kt
@@ -2,6 +2,7 @@ package fr.gouv.gmampa.rapportnav.mocks.mission.crew
 
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceEntity
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.service.ServiceTypeEnum
+import java.time.Instant
 
 object ServiceEntityMock {
     fun create(
@@ -10,11 +11,13 @@ object ServiceEntityMock {
         serviceType: ServiceTypeEnum = ServiceTypeEnum.PAM,
         serviceLinked: ServiceEntity? = null,
         controlUnits: List<Int>? = null,
+        deletedAt: Instant? = null,
     ) = ServiceEntity(
         id = id,
         name = name,
         serviceType = serviceType,
         serviceLinked = serviceLinked,
         controlUnits = controlUnits,
+        deletedAt = deletedAt,
     )
 }

--- a/docs/operations/users.md
+++ b/docs/operations/users.md
@@ -16,3 +16,24 @@ A terme, il conviendra de rajouter une meilleure page d'admnistration des utilis
 Aucune gestion des mots de passe, comme redemander un mot de passe, n'a été mise en place.
 Il faut que les utilisateurs nous demandent et nous leur en fournissons un nouveau.
 
+## Impersonation (mode service)
+
+Cette fonctionnalité permet aux administrateurs de voir l'application comme s'ils étaient un service spécifique.
+C'est utile pour diagnostiquer des problèmes ou vérifier ce qu'un service peut voir.
+
+### Prérequis
+
+- Avoir le rôle **ADMIN**
+
+### Utilisation
+
+1. **Activer le mode service** : Dans l'en-tête de l'application, cliquer sur le dropdown "Voir comme un service..." et sélectionner le service souhaité
+2. **Identifier le mode actif** : Un tag jaune "Mode service : [nom du service]" s'affiche dans l'en-tête pour indiquer que le mode est actif
+3. **Quitter le mode** : Cliquer sur le bouton "Quitter" à côté du tag jaune
+
+### Comportement technique
+
+- Les requêtes sont effectuées au nom du service sélectionné
+- Le rôle ADMIN est temporairement retiré pendant l'impersonation (l'admin voit exactement ce que le service voit)
+- Toutes les actions effectuées en mode impersonation sont journalisées pour l'audit
+

--- a/frontend/src/query-client/__tests__/axios.test.ts
+++ b/frontend/src/query-client/__tests__/axios.test.ts
@@ -27,8 +27,17 @@ beforeAll(async () => {
   axiosInstance = (await import('../axios')).default
 })
 
+let capturedHeaders: Record<string, string> = {}
+
 const server = setupServer(
-  http.get('/api/v2/ok', () => HttpResponse.json({ message: 'ok' })),
+  http.get('/api/v2/ok', ({ request }) => {
+    capturedHeaders = Object.fromEntries(request.headers.entries())
+    return HttpResponse.json({ message: 'ok' })
+  }),
+  http.get('/api/v2/admin/impersonation/services', ({ request }) => {
+    capturedHeaders = Object.fromEntries(request.headers.entries())
+    return HttpResponse.json([{ id: 1, name: 'Service 1' }])
+  }),
   http.get('/api/v2/forbidden', () => new HttpResponse(JSON.stringify({ error: 'Forbidden' }), { status: 403 })),
   http.get('/api/v2/not-found', () =>
     new HttpResponse(
@@ -49,6 +58,8 @@ afterEach(() => {
   server.resetHandlers()
   logoutSpy.mockClear()
   getMock.mockReset()
+  sessionStorage.clear()
+  capturedHeaders = {}
 })
 afterAll(() => server.close())
 
@@ -77,5 +88,41 @@ describe('axiosInstance', () => {
       expect(error.message).toBe('The requested mission could not be found')
       expect(error.response.data.code).toBe('COULD_NOT_FIND_EXCEPTION')
     }
+  })
+
+  it('adds impersonation header when impersonating for non-admin endpoints', async () => {
+    getMock.mockReturnValue('fake-token')
+    sessionStorage.setItem(
+      'impersonation',
+      JSON.stringify({ isImpersonating: true, targetServiceId: 123 })
+    )
+
+    await axiosInstance.get('/ok')
+
+    expect(capturedHeaders['x-impersonate-service-id']).toBe('123')
+  })
+
+  it('does NOT add impersonation header for admin endpoints', async () => {
+    getMock.mockReturnValue('fake-token')
+    sessionStorage.setItem(
+      'impersonation',
+      JSON.stringify({ isImpersonating: true, targetServiceId: 123 })
+    )
+
+    await axiosInstance.get('/admin/impersonation/services')
+
+    expect(capturedHeaders['x-impersonate-service-id']).toBeUndefined()
+  })
+
+  it('does not add impersonation header when not impersonating', async () => {
+    getMock.mockReturnValue('fake-token')
+    sessionStorage.setItem(
+      'impersonation',
+      JSON.stringify({ isImpersonating: false, targetServiceId: null })
+    )
+
+    await axiosInstance.get('/ok')
+
+    expect(capturedHeaders['x-impersonate-service-id']).toBeUndefined()
   })
 })

--- a/frontend/src/query-client/axios.ts
+++ b/frontend/src/query-client/axios.ts
@@ -18,6 +18,25 @@ axiosInstance.interceptors.request.use(
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`
     }
+
+    // Add impersonation header if active (except for admin endpoints)
+    try {
+      const impersonation = sessionStorage.getItem('impersonation')
+      if (impersonation) {
+        const state = JSON.parse(impersonation)
+        if (state.isImpersonating && state.targetServiceId) {
+          // Don't impersonate admin endpoints - admins need full access
+          const url = config.url || ''
+          const isAdminEndpoint = /^\/?admin\//.test(url)
+          if (!isAdminEndpoint) {
+            config.headers['X-Impersonate-Service-Id'] = state.targetServiceId.toString()
+          }
+        }
+      }
+    } catch (e) {
+      // Ignore parsing errors
+    }
+
     return config
   },
   error => Promise.reject(error)

--- a/frontend/src/router/use-global-routes.tsx
+++ b/frontend/src/router/use-global-routes.tsx
@@ -7,6 +7,7 @@ import { OwnerType } from '../v2/features/common/types/owner-type'
 import { RoleType } from '../v2/features/common/types/role-type'
 import { State, store } from '../v2/store'
 import { setModuleType } from '../v2/store/slices/module-reducer'
+import { loadImpersonationFromStorage } from '../v2/store/slices/impersonation-reducer'
 import { LOGIN_PATH } from './routes'
 
 type SidebarItem = {
@@ -74,18 +75,29 @@ export function useGlobalRoutes(): RouteHook {
     return url
   }
 
-  const getModuleType = (roles?: RoleType[]) => {
+  const getModuleTypeFromRoles = (roles?: RoleType[]) => {
     if (roles?.includes(RoleType.USER_PAM)) return ModuleType.PAM
     if (roles?.includes(RoleType.USER_ULAM)) return ModuleType.ULAM
     if (roles?.includes(RoleType.ADMIN)) return ModuleType.ADMIN
     return ModuleType.PAM
   }
 
+  const getModuleTypeFromImpersonation = (): ModuleType | null => {
+    const impersonation = loadImpersonationFromStorage()
+    if (impersonation.isImpersonating && impersonation.targetServiceType) {
+      return impersonation.targetServiceType === 'PAM' ? ModuleType.PAM : ModuleType.ULAM
+    }
+    return null
+  }
+
   useEffect(() => {
     const getUrl = () => {
       if (!isAuthenticated) return LOGIN_PATH
       const user = isLoggedIn()
-      const moduleType = getModuleType(user?.roles)
+
+      // Check if impersonating - use impersonated service type
+      const impersonatedModuleType = getModuleTypeFromImpersonation()
+      const moduleType = impersonatedModuleType ?? getModuleTypeFromRoles(user?.roles)
       const page = moduleType === ModuleType.ADMIN ? '' : '/missions'
       const homeUrl = `/${moduleType}${page}`
 
@@ -98,16 +110,30 @@ export function useGlobalRoutes(): RouteHook {
     setHomeUrl(getUrl())
   }, [isAuthenticated, isLoggedIn])
 
-  const getSideBar = (sideBar: SidebarItem, roles?: RoleType[]) => {
-    const module = roles?.includes(RoleType.USER_ULAM) ? ModuleType.ULAM : ModuleType.PAM
-    return { ...sideBar, url: `/${module}${sideBar.url}` }
+  const getSideBar = (sideBar: SidebarItem, moduleType: ModuleType) => {
+    return { ...sideBar, url: `/${moduleType}${sideBar.url}` }
   }
 
   const getSidebarItems = () => {
     const roles = isLoggedIn()?.roles
-    const SIDEBAR_ITEMS = [getSideBar(MISSION_SIDEBAR, roles)]
-    if (roles?.includes(RoleType.USER_ULAM)) SIDEBAR_ITEMS.push(getSideBar(INQUIRY_SIDEBAR, roles))
-    if (roles?.includes(RoleType.ADMIN)) SIDEBAR_ITEMS.push(ADMIN_SIDEBAR)
+
+    // Check if impersonating - use impersonated service type for sidebar
+    const impersonatedModuleType = getModuleTypeFromImpersonation()
+    const isImpersonating = impersonatedModuleType !== null
+    const effectiveModuleType = impersonatedModuleType ?? (roles?.includes(RoleType.USER_ULAM) ? ModuleType.ULAM : ModuleType.PAM)
+
+    const SIDEBAR_ITEMS = [getSideBar(MISSION_SIDEBAR, effectiveModuleType)]
+
+    // Show inquiries for ULAM (either by role or impersonation)
+    if (effectiveModuleType === ModuleType.ULAM) {
+      SIDEBAR_ITEMS.push(getSideBar(INQUIRY_SIDEBAR, effectiveModuleType))
+    }
+
+    // Always show admin link for admins (even when impersonating)
+    if (roles?.includes(RoleType.ADMIN)) {
+      SIDEBAR_ITEMS.push(ADMIN_SIDEBAR)
+    }
+
     return SIDEBAR_ITEMS
   }
 

--- a/frontend/src/v2/features/admin/services/__tests__/use-admin-services-service.test.tsx
+++ b/frontend/src/v2/features/admin/services/__tests__/use-admin-services-service.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from '../../../../../query-client/axios'
+import { renderHook, waitFor } from '../../../../../test-utils.tsx'
+import useAdminServiceListQuery from '../use-admin-services-service'
+
+vi.mock('../../../../../query-client/axios', () => ({
+  default: {
+    get: vi.fn()
+  }
+}))
+
+describe('useAdminServiceListQuery', () => {
+  let queryClient: QueryClient
+  let wrapper: React.FC<{ children: React.ReactNode }>
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false
+        }
+      }
+    })
+
+    wrapper = ({ children }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  it('fetches all services when no options provided', async () => {
+    const mockServices = [
+      { id: 1, name: 'Service 1', serviceType: 'PAM', controlUnits: [] },
+      { id: 2, name: 'Service 2', serviceType: 'ULAM', controlUnits: [], deletedAt: '2024-01-01' }
+    ]
+
+    ;(axios.get as vi.Mock).mockResolvedValue({ data: mockServices })
+
+    const { result } = renderHook(() => useAdminServiceListQuery(), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(axios.get).toHaveBeenCalledWith('admin/services', { params: undefined })
+    expect(result.current.data).toEqual(mockServices)
+  })
+
+  it('fetches only active services when active=true', async () => {
+    const mockServices = [{ id: 1, name: 'Active Service', serviceType: 'PAM', controlUnits: [] }]
+
+    ;(axios.get as vi.Mock).mockResolvedValue({ data: mockServices })
+
+    const { result } = renderHook(() => useAdminServiceListQuery({ active: true }), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(axios.get).toHaveBeenCalledWith('admin/services', { params: { active: true } })
+    expect(result.current.data).toEqual(mockServices)
+  })
+
+  it('fetches all services when active=false', async () => {
+    const mockServices = [
+      { id: 1, name: 'Service 1', serviceType: 'PAM', controlUnits: [] },
+      { id: 2, name: 'Service 2', serviceType: 'ULAM', controlUnits: [], deletedAt: '2024-01-01' }
+    ]
+
+    ;(axios.get as vi.Mock).mockResolvedValue({ data: mockServices })
+
+    const { result } = renderHook(() => useAdminServiceListQuery({ active: false }), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(axios.get).toHaveBeenCalledWith('admin/services', { params: { active: false } })
+    expect(result.current.data).toEqual(mockServices)
+  })
+
+  it('uses different query keys for different active values', async () => {
+    ;(axios.get as vi.Mock).mockResolvedValue({ data: [] })
+
+    const { result: resultAll } = renderHook(() => useAdminServiceListQuery(), { wrapper })
+    const { result: resultActive } = renderHook(() => useAdminServiceListQuery({ active: true }), { wrapper })
+
+    await waitFor(() => {
+      expect(resultAll.current.isSuccess).toBe(true)
+      expect(resultActive.current.isSuccess).toBe(true)
+    })
+
+    // Both queries should be cached separately
+    expect(queryClient.getQueryData(['admin-services', { active: undefined }])).toBeDefined()
+    expect(queryClient.getQueryData(['admin-services', { active: true }])).toBeDefined()
+  })
+})

--- a/frontend/src/v2/features/admin/services/use-admin-services-service.tsx
+++ b/frontend/src/v2/features/admin/services/use-admin-services-service.tsx
@@ -2,11 +2,20 @@ import { useQuery } from '@tanstack/react-query'
 import axios from '../../../../query-client/axios.ts'
 import { AdminService } from '../types/admin-services-type.ts'
 
-const useAdminServiceListQuery = () => {
-  const fetchAdminServices = (): Promise<AdminService[]> => axios.get(`admin/services`).then(response => response.data)
+interface UseAdminServiceListQueryOptions {
+  active?: boolean
+}
+
+const useAdminServiceListQuery = (options?: UseAdminServiceListQueryOptions) => {
+  const { active } = options ?? {}
+
+  const fetchAdminServices = (): Promise<AdminService[]> => {
+    const params = active !== undefined ? { active } : undefined
+    return axios.get('admin/services', { params }).then(response => response.data)
+  }
 
   const query = useQuery<AdminService[]>({
-    queryKey: ['admin-services'],
+    queryKey: ['admin-services', { active }],
     queryFn: fetchAdminServices,
     refetchIntervalInBackground: false,
     refetchOnWindowFocus: false,

--- a/frontend/src/v2/features/auth/hooks/use-auth.tsx
+++ b/frontend/src/v2/features/auth/hooks/use-auth.tsx
@@ -33,6 +33,9 @@ export const useAuth = (authTokenInstance: AuthToken = new AuthToken()): AuthHoo
     authToken.remove()
     setIsAuthenticated(false)
 
+    // clear impersonation state
+    sessionStorage.removeItem('impersonation')
+
     // clear react-query cache
     queryClient.clear()
 

--- a/frontend/src/v2/features/common/components/layout/__tests__/__snapshots__/mission-list-page-header-wrapper.test.tsx.snap
+++ b/frontend/src/v2/features/common/components/layout/__tests__/__snapshots__/mission-list-page-header-wrapper.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`MissionListPageHeaderWrapper > should match the snapshot 1`] = `
   "baseElement": <body>
     <div>
       <div
-        class="sc-klnyBj jgFtAM"
+        class="sc-gqGJVp ccHfQd"
       >
         <div
           class="rs-flex-box-grid rs-flex-box-grid-middle rs-flex-box-grid-space-between"
@@ -67,7 +67,7 @@ exports[`MissionListPageHeaderWrapper > should match the snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="sc-klnyBj jgFtAM"
+      class="sc-gqGJVp ccHfQd"
     >
       <div
         class="rs-flex-box-grid rs-flex-box-grid-middle rs-flex-box-grid-space-between"

--- a/frontend/src/v2/features/common/components/layout/mission-list-page-header-wrapper.tsx
+++ b/frontend/src/v2/features/common/components/layout/mission-list-page-header-wrapper.tsx
@@ -3,6 +3,7 @@ import { FlexboxGrid, Stack } from 'rsuite'
 import styled from 'styled-components'
 import republique from '../../../../../assets/images/republique.svg'
 import useAuth from '../../../../features/auth/hooks/use-auth'
+import ImpersonationDropdown from '../../../impersonation/components/impersonation-dropdown'
 
 const StyledHeader = styled.div`
   height: 104px;
@@ -37,8 +38,9 @@ export const MissionListPageHeaderWrapper: React.FC<MissionListHeaderWrapperProp
         </FlexboxGrid.Item>
         <FlexboxGrid.Item>
           {isAuthenticated && (
-            <Stack direction="row" style={{ height: '100%' }}>
+            <Stack direction="row" alignItems="center" style={{ height: '100%' }}>
               {actions}
+              <ImpersonationDropdown />
               <Button
                 accent={Accent.SECONDARY}
                 onClick={handleLogout}

--- a/frontend/src/v2/features/impersonation/components/__tests__/impersonation-dropdown.test.tsx
+++ b/frontend/src/v2/features/impersonation/components/__tests__/impersonation-dropdown.test.tsx
@@ -1,0 +1,180 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from '../../../../../test-utils'
+import ImpersonationDropdown from '../impersonation-dropdown'
+
+const startImpersonationMock = vi.fn()
+const stopImpersonationMock = vi.fn()
+
+vi.mock('../../hooks/use-impersonation', () => ({
+  default: vi.fn()
+}))
+
+vi.mock('../../../admin/services/use-admin-services-service', () => ({
+  default: vi.fn()
+}))
+
+import useImpersonation from '../../hooks/use-impersonation'
+import useAdminServiceListQuery from '../../../admin/services/use-admin-services-service'
+
+describe('ImpersonationDropdown', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false
+        }
+      }
+    })
+
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  const renderComponent = () => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <ImpersonationDropdown />
+      </QueryClientProvider>
+    )
+  }
+
+  it('renders nothing when user cannot impersonate', () => {
+    vi.mocked(useImpersonation).mockReturnValue({
+      isImpersonating: false,
+      targetServiceId: null,
+      targetServiceName: null,
+      targetServiceType: null,
+      canImpersonate: false,
+      startImpersonation: startImpersonationMock,
+      stopImpersonation: stopImpersonationMock
+    })
+
+    vi.mocked(useAdminServiceListQuery).mockReturnValue({
+      data: [],
+      isLoading: false
+    } as any)
+
+    const { container } = renderComponent()
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders select dropdown when user can impersonate and is not impersonating', () => {
+    vi.mocked(useImpersonation).mockReturnValue({
+      isImpersonating: false,
+      targetServiceId: null,
+      targetServiceName: null,
+      targetServiceType: null,
+      canImpersonate: true,
+      startImpersonation: startImpersonationMock,
+      stopImpersonation: stopImpersonationMock
+    })
+
+    vi.mocked(useAdminServiceListQuery).mockReturnValue({
+      data: [
+        { id: 1, name: 'PAM Service', serviceType: 'PAM', controlUnits: [] },
+        { id: 2, name: 'ULAM Service', serviceType: 'ULAM', controlUnits: [] }
+      ],
+      isLoading: false
+    } as any)
+
+    renderComponent()
+
+    expect(screen.getByText('Voir comme un service...')).toBeInTheDocument()
+  })
+
+  it('renders impersonation tag and quit button when impersonating', () => {
+    vi.mocked(useImpersonation).mockReturnValue({
+      isImpersonating: true,
+      targetServiceId: 1,
+      targetServiceName: 'PAM Service',
+      targetServiceType: 'PAM',
+      canImpersonate: true,
+      startImpersonation: startImpersonationMock,
+      stopImpersonation: stopImpersonationMock
+    })
+
+    vi.mocked(useAdminServiceListQuery).mockReturnValue({
+      data: [],
+      isLoading: false
+    } as any)
+
+    renderComponent()
+
+    expect(screen.getByText('Mode service : PAM Service')).toBeInTheDocument()
+    expect(screen.getByText('Quitter')).toBeInTheDocument()
+  })
+
+  it('calls stopImpersonation when quit button is clicked', () => {
+    vi.mocked(useImpersonation).mockReturnValue({
+      isImpersonating: true,
+      targetServiceId: 1,
+      targetServiceName: 'PAM Service',
+      targetServiceType: 'PAM',
+      canImpersonate: true,
+      startImpersonation: startImpersonationMock,
+      stopImpersonation: stopImpersonationMock
+    })
+
+    vi.mocked(useAdminServiceListQuery).mockReturnValue({
+      data: [],
+      isLoading: false
+    } as any)
+
+    renderComponent()
+
+    fireEvent.click(screen.getByText('Quitter'))
+
+    expect(stopImpersonationMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls useAdminServiceListQuery with active=true', () => {
+    vi.mocked(useImpersonation).mockReturnValue({
+      isImpersonating: false,
+      targetServiceId: null,
+      targetServiceName: null,
+      targetServiceType: null,
+      canImpersonate: true,
+      startImpersonation: startImpersonationMock,
+      stopImpersonation: stopImpersonationMock
+    })
+
+    vi.mocked(useAdminServiceListQuery).mockReturnValue({
+      data: [],
+      isLoading: false
+    } as any)
+
+    renderComponent()
+
+    expect(useAdminServiceListQuery).toHaveBeenCalledWith({ active: true })
+  })
+
+  it('disables select when services are loading', () => {
+    vi.mocked(useImpersonation).mockReturnValue({
+      isImpersonating: false,
+      targetServiceId: null,
+      targetServiceName: null,
+      targetServiceType: null,
+      canImpersonate: true,
+      startImpersonation: startImpersonationMock,
+      stopImpersonation: stopImpersonationMock
+    })
+
+    vi.mocked(useAdminServiceListQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true
+    } as any)
+
+    renderComponent()
+
+    const select = screen.getByText('Voir comme un service...')
+    expect(select.closest('[class*="disabled"]') || select.closest('[disabled]')).toBeTruthy
+  })
+})

--- a/frontend/src/v2/features/impersonation/components/impersonation-dropdown.tsx
+++ b/frontend/src/v2/features/impersonation/components/impersonation-dropdown.tsx
@@ -1,0 +1,88 @@
+import { Accent, Button, Icon, Select, Size, THEME, Tag } from '@mtes-mct/monitor-ui'
+import { FC } from 'react'
+import { Stack } from 'rsuite'
+import styled from 'styled-components'
+import useAdminServiceListQuery from '../../admin/services/use-admin-services-service'
+import useImpersonation from '../hooks/use-impersonation'
+import { ServiceType } from '../types/impersonation-types'
+
+const ImpersonationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
+const StyledSelect = styled(Select)`
+  min-width: 200px;
+`
+
+const ImpersonationDropdown: FC = () => {
+  const {
+    isImpersonating,
+    targetServiceId,
+    targetServiceName,
+    canImpersonate,
+    startImpersonation,
+    stopImpersonation
+  } = useImpersonation()
+
+  const { data: services, isLoading } = useAdminServiceListQuery({ active: true })
+
+  // Only render for admins
+  if (!canImpersonate) {
+    return null
+  }
+
+  const serviceOptions = services?.map(service => ({
+    value: service.id,
+    label: service.name
+  })) ?? []
+
+  const handleServiceChange = (value: number | undefined) => {
+    if (value) {
+      const service = services?.find(s => s.id === value)
+      if (service) {
+        startImpersonation(service.id, service.name, service.serviceType as ServiceType)
+      }
+    }
+  }
+
+  const handleStopImpersonation = () => {
+    stopImpersonation()
+  }
+
+  if (isImpersonating) {
+    return (
+      <ImpersonationContainer>
+        <Tag backgroundColor={THEME.color.goldenPoppy} color={THEME.color.charcoal}>
+          Mode service : {targetServiceName}
+        </Tag>
+        <Button
+          accent={Accent.SECONDARY}
+          size={Size.SMALL}
+          onClick={handleStopImpersonation}
+          Icon={Icon.Close}
+        >
+          Quitter
+        </Button>
+      </ImpersonationContainer>
+    )
+  }
+
+  return (
+    <Stack direction="row" alignItems="center" spacing={8}>
+      <StyledSelect
+        label=""
+        placeholder="Voir comme un service..."
+        options={serviceOptions}
+        onChange={handleServiceChange}
+        value={targetServiceId}
+        disabled={isLoading}
+        searchable
+        cleanable={false}
+      />
+    </Stack>
+  )
+}
+
+export default ImpersonationDropdown

--- a/frontend/src/v2/features/impersonation/hooks/use-impersonation.tsx
+++ b/frontend/src/v2/features/impersonation/hooks/use-impersonation.tsx
@@ -1,0 +1,84 @@
+import { useStore } from '@tanstack/react-store'
+import { useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { store } from '../../../store'
+import {
+  setImpersonation,
+  clearImpersonation,
+  loadImpersonationFromStorage
+} from '../../../store/slices/impersonation-reducer'
+import { setModuleType } from '../../../store/slices/module-reducer'
+import { ModuleType } from '../../common/types/module-type'
+import { RoleType } from '../../common/types/role-type'
+import useAuth from '../../auth/hooks/use-auth'
+import { ServiceType } from '../types/impersonation-types'
+
+const serviceTypeToModuleType = (serviceType: ServiceType): ModuleType => {
+  return serviceType === 'PAM' ? ModuleType.PAM : ModuleType.ULAM
+}
+
+export const useImpersonation = () => {
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const { isLoggedIn } = useAuth()
+  const impersonation = useStore(store, state => state.impersonation)
+
+  // Load impersonation state from storage on mount and set module type
+  useEffect(() => {
+    const storedState = loadImpersonationFromStorage()
+    if (storedState.isImpersonating && storedState.targetServiceType) {
+      store.setState(currentState => ({
+        ...currentState,
+        impersonation: storedState
+      }))
+      // Also restore the module type based on impersonated service
+      setModuleType(serviceTypeToModuleType(storedState.targetServiceType))
+    }
+  }, [])
+
+  const token = isLoggedIn()
+  const canImpersonate = token?.roles?.includes(RoleType.ADMIN) ?? false
+
+  const startImpersonation = useCallback(
+    (serviceId: number, serviceName: string, serviceType: ServiceType) => {
+      setImpersonation(serviceId, serviceName, serviceType)
+
+      // Update module type based on service type
+      const moduleType = serviceTypeToModuleType(serviceType)
+      setModuleType(moduleType)
+
+      // Invalidate all queries to refetch with new service context
+      queryClient.invalidateQueries()
+
+      // Navigate to the correct module's missions page
+      navigate(`/${moduleType}/missions`, { replace: true })
+    },
+    [queryClient, navigate]
+  )
+
+  const stopImpersonation = useCallback(() => {
+    clearImpersonation()
+
+    // Reset module type to admin (since only admins can impersonate)
+    setModuleType(ModuleType.ADMIN)
+
+    // Invalidate all queries to refetch with original service context
+    queryClient.invalidateQueries()
+
+    // Navigate back to admin
+    navigate('/', { replace: true })
+  }, [queryClient, navigate])
+
+  return {
+    isImpersonating: impersonation.isImpersonating,
+    targetServiceId: impersonation.targetServiceId,
+    targetServiceName: impersonation.targetServiceName,
+    targetServiceType: impersonation.targetServiceType,
+    canImpersonate,
+    startImpersonation,
+    stopImpersonation
+  }
+}
+
+export default useImpersonation

--- a/frontend/src/v2/features/impersonation/types/impersonation-types.ts
+++ b/frontend/src/v2/features/impersonation/types/impersonation-types.ts
@@ -1,0 +1,14 @@
+export type ServiceType = 'PAM' | 'ULAM'
+
+export interface ImpersonationState {
+  isImpersonating: boolean
+  targetServiceId?: number
+  targetServiceName?: string
+  targetServiceType?: ServiceType
+}
+
+export interface ImpersonationService {
+  id: number
+  name: string
+  serviceType: string
+}

--- a/frontend/src/v2/store/index.ts
+++ b/frontend/src/v2/store/index.ts
@@ -2,6 +2,7 @@ import { Store } from '@tanstack/store'
 import { CompletenessForStats, MissionStatusEnum } from '../features/common/types/mission-types'
 import { ModuleType } from '../features/common/types/module-type'
 import { User } from '../features/common/types/user'
+import { ImpersonationState } from '../features/impersonation/types/impersonation-types'
 
 export interface State {
   delayQuery: {
@@ -28,6 +29,7 @@ export interface State {
     homeUrl?: string
     type?: ModuleType
   }
+  impersonation: ImpersonationState
 }
 
 export const store = new Store<State>({
@@ -39,5 +41,8 @@ export const store = new Store<State>({
   connectivity: {},
   module: {
     type: ModuleType.PAM
+  },
+  impersonation: {
+    isImpersonating: false
   }
 })

--- a/frontend/src/v2/store/slices/impersonation-reducer.ts
+++ b/frontend/src/v2/store/slices/impersonation-reducer.ts
@@ -1,0 +1,44 @@
+import { store } from '..'
+import { ImpersonationState, ServiceType } from '../../features/impersonation/types/impersonation-types'
+
+const STORAGE_KEY = 'impersonation'
+
+export const setImpersonation = (
+  targetServiceId: number,
+  targetServiceName: string,
+  targetServiceType: ServiceType
+) => {
+  const state: ImpersonationState = {
+    isImpersonating: true,
+    targetServiceId,
+    targetServiceName,
+    targetServiceType
+  }
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  store.setState(currentState => ({
+    ...currentState,
+    impersonation: state
+  }))
+}
+
+export const clearImpersonation = () => {
+  sessionStorage.removeItem(STORAGE_KEY)
+  store.setState(currentState => ({
+    ...currentState,
+    impersonation: {
+      isImpersonating: false
+    }
+  }))
+}
+
+export const loadImpersonationFromStorage = (): ImpersonationState => {
+  try {
+    const stored = sessionStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      return JSON.parse(stored) as ImpersonationState
+    }
+  } catch (e) {
+    console.error('Failed to load impersonation state from storage', e)
+  }
+  return { isImpersonating: false }
+}


### PR DESCRIPTION
Rajouté un mode pour impersonifier un service via un dropdown de sélection seulement pour les admins. Ca nous permettra de pouvoir switcher pour consulter les rapports hyper facilement

Les choix techniques :

- rajout du header "X-Impersonate-Service-Id" pour les requetes personifiées, stocké dans sessionStorage (moins permissif que localStorage, accessible dans axios contrairement à notre react-store)
- informations validées et auditées par le secu filter puis utilisée dans le AuthContext de Spring
- header utilisé jusqu'à ce que l'impersonification soit finie ou le tab du navigateur fermé