### PR TITLE
fix(formik): remove isMissionFinished as form field

### DIFF
--- a/frontend/src/v2/features/common/hooks/use-action-registry.tsx
+++ b/frontend/src/v2/features/common/hooks/use-action-registry.tsx
@@ -20,7 +20,6 @@ export type ActionRegistryItem = {
   component?: FunctionComponent<{
     action: MissionAction
     onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
-    isMissionFinished?: boolean
   }>
 }
 

--- a/frontend/src/v2/features/mission-action/components/elements/mission-action-item-control.tsx
+++ b/frontend/src/v2/features/mission-action/components/elements/mission-action-item-control.tsx
@@ -8,13 +8,12 @@ import MissionActionItemNavControl from './mission-action-item-nav-control'
 const MissionActionItemControl: FC<{
   action: MissionAction
   onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
-  isMissionFinished?: boolean
-}> = ({ action, onChange, isMissionFinished }) => {
+}> = ({ action, onChange }) => {
   switch (action.source) {
     case MissionSourceEnum.MONITORENV:
       return <MissionActionItemEnvControl action={action} onChange={onChange} />
     case MissionSourceEnum.MONITORFISH:
-      return <MissionActionItemFishControl action={action} onChange={onChange} isMissionFinished={isMissionFinished} />
+      return <MissionActionItemFishControl action={action} onChange={onChange} />
     default:
       return <MissionActionItemNavControl action={action} onChange={onChange} />
   }

--- a/frontend/src/v2/features/mission-action/components/elements/mission-action-item-env-control.tsx
+++ b/frontend/src/v2/features/mission-action/components/elements/mission-action-item-env-control.tsx
@@ -19,17 +19,12 @@ import { MissionActionFormikCoordinateInputDMD } from '../ui/mission-action-form
 
 export type MissionActionItemEnvControlProps = {
   action: MissionAction
-  isMissionFinished?: boolean
   onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
 }
 
-const MissionActionItemEnvControl: React.FC<MissionActionItemEnvControlProps> = ({
-  action,
-  onChange,
-  isMissionFinished
-}) => {
+const MissionActionItemEnvControl: React.FC<MissionActionItemEnvControlProps> = ({ action, onChange }) => {
   const { getAvailableEnvControlTypes } = useTarget()
-  const { initValue, handleSubmit } = useMissionActionEnvControl(action, onChange, isMissionFinished)
+  const { initValue, handleSubmit } = useMissionActionEnvControl(action, onChange)
 
   return (
     <form style={{ width: '100%' }}>

--- a/frontend/src/v2/features/mission-action/components/elements/mission-action-item-fish-control.tsx
+++ b/frontend/src/v2/features/mission-action/components/elements/mission-action-item-fish-control.tsx
@@ -23,9 +23,8 @@ import { MissionActionFormikCoordinateInputDMD } from '../ui/mission-action-form
 const MissionActionItemFishControl: FC<{
   action: MissionAction
   onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
-  isMissionFinished?: boolean
-}> = ({ action, onChange, isMissionFinished }) => {
-  const { initValue, handleSubmit } = useMissionActionFishControl(action, onChange, isMissionFinished)
+}> = ({ action, onChange }) => {
+  const { initValue, handleSubmit } = useMissionActionFishControl(action, onChange)
   return (
     <div style={{ width: '100%' }}>
       {initValue && (

--- a/frontend/src/v2/features/mission-action/components/elements/mission-action-item-generic-control.tsx
+++ b/frontend/src/v2/features/mission-action/components/elements/mission-action-item-generic-control.tsx
@@ -22,7 +22,6 @@ export type MissionActionItemGenericControlProps = {
   schema?: ObjectShape
   withGeoCoords?: boolean
   controlTypes?: ControlType[]
-  isMissionFinished?: boolean
   isGeoCoordRequired?: boolean
   component?: FunctionComponent<{ formik: FormikProps<ActionControlInput> }>
   onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
@@ -35,7 +34,6 @@ const MissionActionItemGenericControl: React.FC<MissionActionItemGenericControlP
   component,
   controlTypes,
   withGeoCoords,
-  isMissionFinished,
   isGeoCoordRequired = true
 }) => {
   const { isOnline } = useOnlineManager()
@@ -44,7 +42,6 @@ const MissionActionItemGenericControl: React.FC<MissionActionItemGenericControlP
     action,
     onChange,
     schema,
-    isMissionFinished,
     withGeoCoords,
     [
       'incidentDuringOperation',

--- a/frontend/src/v2/features/mission-action/components/elements/mission-action-item-illegal-immigration.tsx
+++ b/frontend/src/v2/features/mission-action/components/elements/mission-action-item-illegal-immigration.tsx
@@ -3,7 +3,6 @@ import { Field, FieldProps, Formik } from 'formik'
 import { FC } from 'react'
 import { Stack } from 'rsuite'
 import { FormikDateRangePicker } from '../../../common/components/ui/formik-date-range-picker'
-import { FormikNumberInput } from '../../../common/components/ui/formik-number-input'
 import { FormikTextAreaInput } from '../../../common/components/ui/formik-textarea-input'
 import { MissionAction } from '../../../common/types/mission-action'
 import { useMissionActionIllegalImmigration } from '../../hooks/use-mission-action-illegal-immigration'
@@ -11,10 +10,10 @@ import { ActionIllegalImmigrationInput } from '../../types/action-type'
 import MissionActionDivingOperation from '../ui/mission-action-diving-operation'
 import { MissionActionFormikCoordinateInputDMD } from '../ui/mission-action-formik-coordonate-input-dmd'
 import MissionActionIncidentDonwload from '../ui/mission-action-incident-download'
+import { FormikNumberInput } from '../../../common/components/ui/formik-number-input.tsx'
 
 const MissionActionItemIllegalImmigration: FC<{
   action: MissionAction
-  isMissionFinished?: boolean
   onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
 }> = ({ action, onChange }) => {
   const { initValue, validationSchema, handleSubmit } = useMissionActionIllegalImmigration(action, onChange)
@@ -71,6 +70,7 @@ const MissionActionItemIllegalImmigration: FC<{
                       <Stack direction={'row'} spacing={'1rem'}>
                         <Stack.Item style={{ flex: 1 }}>
                           <FormikNumberInput
+                            isRequired={true}
                             name="nbOfInterceptedMigrants"
                             role="nbOfInterceptedMigrants"
                             label="Nb de migrants interceptés"

--- a/frontend/src/v2/features/mission-action/components/elements/mission-action-item-status.tsx
+++ b/frontend/src/v2/features/mission-action/components/elements/mission-action-item-status.tsx
@@ -13,7 +13,6 @@ import { ActionStatusInput } from '../../types/action-type'
 const MissionActionItemStatus: FC<{
   action: MissionNavAction
   onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
-  isMissionFinished?: boolean
 }> = ({ action, onChange }) => {
   const { initValue, handleSubmit, validationSchema } = useMissionActionStatus(action, onChange)
   return (

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-anti-pollution.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-anti-pollution.tsx
@@ -17,7 +17,7 @@ export function useMissionActionAntiPollution(
   const { getCoords } = useCoordinate()
   const value = action?.data as MissionNavActionData
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
-  const isMissionFinished = useMissionFinished(action.missionId)
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionNavActionData): ActionAntiPollutionInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)
@@ -25,7 +25,6 @@ export function useMissionActionAntiPollution(
     return {
       ...data,
       dates: [startDate, endDate],
-      isMissionFinished,
       geoCoords: getCoords(data.latitude, data.longitude)
     }
   }

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-env-control.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-env-control.tsx
@@ -5,15 +5,16 @@ import { useDate } from '../../common/hooks/use-date'
 import { AbstractFormikSubFormHook } from '../../common/types/abstract-formik-hook'
 import { MissionAction, MissionEnvActionData } from '../../common/types/mission-action'
 import { ActionEnvControlInput } from '../types/action-type'
+import { useMissionFinished } from '../../common/hooks/use-mission-finished.tsx'
 
 export function useMissionActionEnvControl(
   action: MissionAction,
-  onChange: (newAction: MissionAction) => Promise<unknown>,
-  isMissionFinished?: boolean
+  onChange: (newAction: MissionAction) => Promise<unknown>
 ): AbstractFormikSubFormHook<ActionEnvControlInput> {
   const value = action?.data as MissionEnvActionData
   const { extractLatLngFromMultiPoint } = useCoordinate()
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionEnvActionData): ActionEnvControlInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)
@@ -21,13 +22,12 @@ export function useMissionActionEnvControl(
     return {
       ...data,
       dates: [startDate, endDate],
-      isMissionFinished: !!isMissionFinished,
       geoCoords: extractLatLngFromMultiPoint(data.geom)
     }
   }
 
   const fromInputToFieldValue = (value: ActionEnvControlInput): MissionEnvActionData => {
-    const { dates, geoCoords, isMissionFinished, ...newData } = value
+    const { dates, geoCoords, ...newData } = value
     const endDateTimeUtc = postprocessDateFromPicker(dates[1])
     const startDateTimeUtc = postprocessDateFromPicker(dates[0])
     return { ...newData, endDateTimeUtc, startDateTimeUtc }

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-fish-control.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-fish-control.tsx
@@ -5,15 +5,16 @@ import { useDate } from '../../common/hooks/use-date'
 import { AbstractFormikSubFormHook } from '../../common/types/abstract-formik-hook'
 import { MissionAction, MissionFishActionData } from '../../common/types/mission-action'
 import { ActionFishControlInput } from '../types/action-type'
+import { useMissionFinished } from '../../common/hooks/use-mission-finished.tsx'
 
 export function useMissionActionFishControl(
   action: MissionAction,
-  onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>,
-  isMissionFinished?: boolean
+  onChange: (newAction: MissionAction, debounceTime?: number) => Promise<unknown>
 ): AbstractFormikSubFormHook<ActionFishControlInput> {
   const { getCoords } = useCoordinate()
   const value = action?.data as MissionFishActionData
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionFishActionData): ActionFishControlInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)
@@ -21,13 +22,12 @@ export function useMissionActionFishControl(
     return {
       ...data,
       dates: [startDate, endDate],
-      isMissionFinished: !!isMissionFinished,
       geoCoords: getCoords(data.latitude, data.longitude)
     }
   }
 
   const fromInputToFieldValue = (value: ActionFishControlInput): MissionFishActionData => {
-    const { dates, geoCoords, isMissionFinished, ...newData } = value
+    const { dates, geoCoords, ...newData } = value
     const endDateTimeUtc = postprocessDateFromPicker(dates[1])
     const startDateTimeUtc = postprocessDateFromPicker(dates[0])
     return { ...newData, startDateTimeUtc, endDateTimeUtc }

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-generic-control.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-generic-control.tsx
@@ -9,17 +9,18 @@ import getGeoCoordsSchema from '../../common/schemas/geocoords-schema'
 import { AbstractFormikSubFormHook } from '../../common/types/abstract-formik-hook'
 import { MissionAction, MissionNavActionData } from '../../common/types/mission-action'
 import { ActionControlInput } from '../types/action-type'
+import { useMissionFinished } from '../../common/hooks/use-mission-finished.tsx'
 
 export function useMissionActionGenericControl(
   action: MissionAction,
   onChange: (newAction: MissionAction) => Promise<unknown>,
   schema?: ObjectShape,
-  isMissionFinished?: boolean,
   withGeoCoords?: boolean,
   booleans?: string[]
 ): AbstractFormikSubFormHook<ActionControlInput> {
   const { getCoords } = useCoordinate()
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionNavActionData): ActionControlInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)
@@ -27,13 +28,12 @@ export function useMissionActionGenericControl(
     return {
       ...data,
       dates: [startDate, endDate],
-      isMissionFinished: !!isMissionFinished,
       geoCoords: getCoords(data.latitude, data.longitude)
     }
   }
 
   const fromInputToFieldValue = (value: ActionControlInput): MissionNavActionData => {
-    const { dates, geoCoords, isMissionFinished, ...newData } = value
+    const { dates, geoCoords, ...newData } = value
     const latitude = geoCoords[0]
     const longitude = geoCoords[1]
     const endDateTimeUtc = postprocessDateFromPicker(dates[1])

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-generic-date-observation.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-generic-date-observation.tsx
@@ -16,7 +16,7 @@ export function useMissionActionGenericDateObservation(
   schema?: ObjectShape
 ): AbstractFormikSubFormHook<ActionGenericDateObservationInput> {
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
-  const isMissionFinished = useMissionFinished(action.missionId)
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionActionData): ActionGenericDateObservationInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-illegal-immigration.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-illegal-immigration.tsx
@@ -19,7 +19,7 @@ export function useMissionActionIllegalImmigration(
   const { getCoords } = useCoordinate()
   const value = action?.data as MissionNavActionData
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
-  const isMissionFinished = useMissionFinished(action.missionId)
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionNavActionData): ActionIllegalImmigrationInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)
@@ -27,13 +27,12 @@ export function useMissionActionIllegalImmigration(
     return {
       ...data,
       dates: [startDate, endDate],
-      isMissionFinished: isMissionFinished,
       geoCoords: getCoords(data.latitude, data.longitude)
     }
   }
 
   const fromInputToFieldValue = (value: ActionIllegalImmigrationInput): MissionNavActionData => {
-    const { dates, geoCoords, isMissionFinished, ...newData } = value
+    const { dates, geoCoords, ...newData } = value
     const latitude = geoCoords[0]
     const longitude = geoCoords[1]
     const endDateTimeUtc = postprocessDateFromPicker(dates[1])

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-nav-control.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-nav-control.tsx
@@ -20,7 +20,7 @@ export function useMissionActionNavControl(
   const { getCoords } = useCoordinate()
   const value = action?.data as MissionNavActionData
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
-  const isMissionFinished = useMissionFinished(action.missionId)
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionNavActionData): ActionNavControlInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)
@@ -28,13 +28,12 @@ export function useMissionActionNavControl(
     return {
       ...data,
       dates: [startDate, endDate],
-      isMissionFinished: isMissionFinished,
       geoCoords: getCoords(data.latitude, data.longitude)
     }
   }
 
   const fromInputToFieldValue = (value: ActionNavControlInput): MissionNavActionData => {
-    const { dates, isMissionFinished, geoCoords, ...newData } = value
+    const { dates, geoCoords, ...newData } = value
     const latitude = geoCoords[0] ?? 0
     const longitude = geoCoords[1] ?? 0
     const endDateTimeUtc = postprocessDateFromPicker(dates[1])

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-rescue.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-rescue.tsx
@@ -20,7 +20,7 @@ export function useMissionActionRescue(
   const { getCoords } = useCoordinate()
   const value = action?.data as MissionNavActionData
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
-  const isMissionFinished = useMissionFinished(action.missionId)
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionNavActionData): ActionRescueInput => {
     const endDate = preprocessDateForPicker(data.endDateTimeUtc)
@@ -30,13 +30,12 @@ export function useMissionActionRescue(
       ...data,
       rescueType,
       dates: [startDate, endDate],
-      isMissionFinished: isMissionFinished,
       geoCoords: getCoords(data.latitude, data.longitude)
     }
   }
 
   const fromInputToFieldValue = (value: ActionRescueInput): MissionNavActionData => {
-    const { dates, geoCoords, isMissionFinished, ...newData } = value
+    const { dates, geoCoords, ...newData } = value
     const latitude = geoCoords[0]
     const longitude = geoCoords[1]
 

--- a/frontend/src/v2/features/mission-action/hooks/use-mission-action-status.tsx
+++ b/frontend/src/v2/features/mission-action/hooks/use-mission-action-status.tsx
@@ -16,7 +16,7 @@ export function useMissionActionStatus(
 ): AbstractFormikSubFormHook<ActionStatusInput> {
   const value = action?.data as MissionNavActionData
   const { preprocessDateForPicker, postprocessDateFromPicker } = useDate()
-  const isMissionFinished = useMissionFinished(action.missionId)
+  const isMissionFinished = useMissionFinished(action.ownerId ?? action.missionId)
 
   const fromFieldValueToInput = (data: MissionNavActionData): ActionStatusInput => {
     return { ...data, date: preprocessDateForPicker(data.startDateTimeUtc) }

--- a/frontend/src/v2/features/mission-action/types/action-type.ts
+++ b/frontend/src/v2/features/mission-action/types/action-type.ts
@@ -2,26 +2,17 @@ import { MissionEnvActionData, MissionFishActionData, MissionNavActionData } fro
 import { MissionActionData } from '../../common/types/mission-action-data'
 import { RescueType } from '../../common/types/rescue-type'
 
-export type ActionGenericDateObservation = {
-  id: string
-  startDateTimeUtc: string
-  endDateTimeUtc: string
-  observations: string
-}
-
 export type ActionGenericDateObservationInput = {
   dates: [Date?, Date?]
 } & MissionActionData
 
 export type ActionAntiPollutionInput = {
   dates: [Date?, Date?]
-  isMissionFinished?: boolean
   geoCoords: (number | undefined)[]
 } & MissionNavActionData
 
 export type ActionIllegalImmigrationInput = {
   dates: [Date?, Date?]
-  isMissionFinished?: boolean
   geoCoords: (number | undefined)[]
 } & MissionNavActionData
 
@@ -30,7 +21,6 @@ export type ActionFreeNoteInput = { date?: Date } & MissionNavActionData
 export type ActionRescueInput = {
   dates: [Date?, Date?]
   rescueType: RescueType
-  isMissionFinished?: boolean
   geoCoords: (number | undefined)[]
 } & MissionNavActionData
 
@@ -40,19 +30,16 @@ export type ActionSurveillanceInput = { dates: [Date?, Date?] } & MissionEnvActi
 
 export type ActionNavControlInput = {
   dates: [Date?, Date?]
-  isMissionFinished: boolean
   geoCoords: (number | undefined)[]
 } & MissionNavActionData
 
 export type ActionFishControlInput = {
   dates: [Date?, Date?]
-  isMissionFinished: boolean
   geoCoords: (number | undefined)[]
 } & MissionFishActionData
 
 export type ActionEnvControlInput = {
   dates: [Date?, Date?]
-  isMissionFinished: boolean
   geoCoords: [number?, number?]
 } & MissionEnvActionData
 
@@ -60,6 +47,5 @@ export type ActionInquiryInput = {} & MissionNavActionData
 
 export type ActionControlInput = {
   dates: [Date?, Date?]
-  isMissionFinished: boolean
   geoCoords: [number?, number?]
 } & MissionNavActionData


### PR DESCRIPTION
J'ai enlevé ce vieux hack que j'avais fait dans le passé car j'avais besoin de isMissionFinished mais maintenant j'utilise le hook. J'ai aussi viré le champ qui était considéré comme un formField et quand il était rajouté, ca déclenchait un FormikEffect parce que le champ a été rajouté aux initValue des forms 