### PR TITLE
fix(formik): read validation from parent for MissionActionFormikCoord…

### DIFF
--- a/frontend/src/v2/features/mission-action/components/ui/__tests__/mission-action-formik-coordonate-input-dmd.test.tsx
+++ b/frontend/src/v2/features/mission-action/components/ui/__tests__/mission-action-formik-coordonate-input-dmd.test.tsx
@@ -1,0 +1,65 @@
+import { FieldProps } from 'formik'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '../../../../../../test-utils'
+import { MissionActionFormikCoordinateInputDMD } from '../mission-action-formik-coordonate-input-dmd'
+
+const createFieldFormik = (value: number[] | undefined, error?: string): FieldProps<number[]> => {
+  const setFieldValue = vi.fn()
+  return {
+    field: {
+      name: 'geoCoords',
+      value: value as number[],
+      onChange: vi.fn(),
+      onBlur: vi.fn()
+    },
+    meta: {
+      value: value as number[],
+      error,
+      touched: false,
+      initialValue: value as number[],
+      initialTouched: false,
+      initialError: undefined
+    },
+    form: {
+      setFieldValue
+    } as any
+  }
+}
+
+describe('MissionActionFormikCoordinateInputDMD', () => {
+  it('renders the coordinate input with label', () => {
+    const fieldFormik = createFieldFormik([48.8566, 2.3522])
+
+    render(<MissionActionFormikCoordinateInputDMD name="geoCoords" fieldFormik={fieldFormik} />)
+
+    expect(screen.getByText(/Lieu de l'opération/)).toBeInTheDocument()
+  })
+
+  it('does not render when fieldFormik value is undefined', () => {
+    const fieldFormik = createFieldFormik(undefined)
+
+    const { container } = render(
+      <MissionActionFormikCoordinateInputDMD name="geoCoords" fieldFormik={fieldFormik} />
+    )
+
+    expect(container.querySelector('input')).not.toBeInTheDocument()
+  })
+
+  it('renders coordinate inputs when value is provided', () => {
+    const fieldFormik = createFieldFormik([48.8566, 2.3522])
+
+    render(<MissionActionFormikCoordinateInputDMD name="geoCoords" fieldFormik={fieldFormik} />)
+
+    const inputs = screen.getAllByRole('textbox')
+    expect(inputs.length).toBeGreaterThan(0)
+  })
+
+  it('does not call setFieldValue on initial render', () => {
+    const fieldFormik = createFieldFormik([48.8566, 2.3522])
+
+    render(<MissionActionFormikCoordinateInputDMD name="geoCoords" fieldFormik={fieldFormik} />)
+
+    // isCoordsEqual prevents unnecessary updates on initial render
+    expect(fieldFormik.form.setFieldValue).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/v2/features/mission-action/components/ui/mission-action-formik-coordonate-input-dmd.tsx
+++ b/frontend/src/v2/features/mission-action/components/ui/mission-action-formik-coordonate-input-dmd.tsx
@@ -1,7 +1,7 @@
+import { useEffect, useState } from 'react'
 import { FormikCoordinatesInputProps, FormikEffect } from '@mtes-mct/monitor-ui'
 import { FieldProps, Formik } from 'formik'
 import { isEqual } from 'lodash'
-import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 import { FormikCoordinateInputDMD } from '../../../common/components/ui/formik-coordonates-input-dmd'
 
@@ -37,7 +37,13 @@ export const MissionActionFormikCoordinateInputDMD = styled(
     return (
       <>
         {initValue && (
-          <Formik initialValues={initValue} onSubmit={handleSubmit} enableReinitialize validateOnChange>
+          <Formik
+            initialValues={initValue}
+            initialErrors={fieldFormik.meta.error ? { coords: fieldFormik.meta.error } : undefined}
+            onSubmit={handleSubmit}
+            enableReinitialize
+            validateOnChange
+          >
             {() => (
               <>
                 <FormikEffect onChange={nextValue => handleSubmit(nextValue as Coords)} />


### PR DESCRIPTION
…inateInputDMD

Je récupère l'erreur du parent via `initialErrors={fieldFormik.meta.error ? { coords: fieldFormik.meta.error } : undefined}`