### PR TITLE
fix(secu): use commit hash instead of tag for defense in depth

### DIFF
--- a/.github/actions/install-and-build-backend/action.yml
+++ b/.github/actions/install-and-build-backend/action.yml
@@ -4,9 +4,9 @@ description: 'Install and build build'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-    - uses: actions/setup-java@v5
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
       with:
         distribution: liberica
         java-version: 25
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: cd backend
 
-    - uses: gradle/actions/setup-gradle@v4
+    - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
       id: setup-gradle
       with:
         gradle-version: wrapper

--- a/.github/actions/install-and-build-frontend/action.yml
+++ b/.github/actions/install-and-build-frontend/action.yml
@@ -5,10 +5,10 @@ version: 'v1.0.0'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         cache: npm
         cache-dependency-path: ./frontend/package-lock.json

--- a/.github/workflows/build-and-test-backend.yml
+++ b/.github/workflows/build-and-test-backend.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install and Build Backend
         uses: ./.github/actions/install-and-build-backend
@@ -30,7 +30,7 @@ jobs:
 
       - name: Add coverage to PR
         id: jacoco
-        uses: madrapps/jacoco-report@v1.7.1
+        uses: madrapps/jacoco-report@50d3aff4548aa991e6753342d9ba291084e63848
         with:
           paths: |
             ${{ github.workspace }}/**/backend/build/reports/jacoco/**/jacocoTestReport.xml

--- a/.github/workflows/build-and-test-frontend.yml
+++ b/.github/workflows/build-and-test-frontend.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install and Build Frontend
         uses: ./.github/actions/install-and-build-frontend
 
       - name: Analyse dependencies
-        uses: oke-py/npm-audit-action@v2
+        uses: oke-py/npm-audit-action@828ccb3b0710dfb351b6e9aaadec963c6953cacf
         with:
           audit_level: high
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
         # Set if: always() to also generate the report if tests are failing
         # Only works if you set `reportOnFailure: true` in your vite config as specified above
         if: always()
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c
         with:
           working-directory: frontend
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,24 +39,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Java JDK
         if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: "liberica"
           java-version: "25"
 
       - name: Setup Node.js
         if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "22"
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
         with:
           languages: ${{ matrix.language }}
 
@@ -68,9 +68,9 @@ jobs:
       # queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
           fail-on-severity: critical

--- a/.github/workflows/release-please-main.yml
+++ b/.github/workflows/release-please-main.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: release-please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
         id: release
         with:
           target-branch: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
       ACTIONS_RUNNER_DEBUG: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Get frontend version
-        uses: avides/actions-project-version-check@v1.4.0
+        uses: avides/actions-project-version-check@884551b972f805b876a514bec199fbfaae21ea72
         id: frontend_version
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VERSION: ${{ steps.frontend_version.outputs.version }}
 
-      - uses: yesolutions/mirror-action@master
+      - uses: yesolutions/mirror-action@1708f16cdb28634fd3ba10c5c79abc91f5578a14
         with:
           REMOTE: https://gitlab-sml.din.developpement-durable.gouv.fr/rapportnav-v2/rapportnav_v2.git
           GIT_USERNAME: ${{ github.actor }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -46,7 +46,7 @@ jobs:
     name: Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
@@ -66,7 +66,7 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install and Build Frontend
         uses: ./.github/actions/install-and-build-frontend

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run Trivy on OS
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Run Trivy on OS
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           scan-type: "fs"
           ignore-unfixed: true
@@ -47,7 +47,7 @@ jobs:
           category: "trivy-os"
 
       - name: Run Trivy on libraries
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           scan-type: "fs"
           ignore-unfixed: true
@@ -63,7 +63,7 @@ jobs:
           category: "trivy-libs"
 
       - name: Run Trivy on IaC/Config (Dockerfiles, docker-compose)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
           scan-type: "config"
           format: "sarif"


### PR DESCRIPTION
Reco de la part de l'ANSSI
En gros, un attaquant, s'il a accès au repo avec status maintainer peut modifier le code en réutilisant le même tag.
En utilisant le commit hash, on se prévient de ce type de manipulation car si le code est modifié, le hash changera alors que le tag pas forcément