### PR TITLE
fix(Analytics): fix truncating conversion to int too early in duration calculation

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/analytics/patrol/operationalSummary/ComputeEnvOperationalSummary.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/analytics/patrol/operationalSummary/ComputeEnvOperationalSummary.kt
@@ -26,12 +26,15 @@ fun execute(actions: List<MissionActionEntity>): Map<String, Any> {
         val surveillances = filteredActions.filter { it.envActionType == ActionTypeEnum.SURVEILLANCE }
 
         val nbSurveillances = surveillances.size
-        val totalSurveillanceDurationInHours = surveillances.sumOf<MissionEnvActionEntity> { surveillance ->
-            ComputeDurationUtils.durationInHours(
+        val totalSurveillanceDurationInSeconds = surveillances.sumOf { surveillance ->
+            ComputeDurationUtils.durationInSeconds(
                 startDateTimeUtc = surveillance.startDateTimeUtc,
                 endDateTimeUtc = surveillance.endDateTimeUtc
-            ).toInt()
+            ) ?: 0
         }
+        val totalSurveillanceDurationInHours = ComputeDurationUtils.convertFromSeconds(
+            totalSurveillanceDurationInSeconds, DurationUnit.HOURS
+        )
 
         val nbControls = controls.size
 

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/analytics/patrol/operationalSummary/ComputeEnvOperationalSummaryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/domain/use_cases/analytics/patrol/operationalSummary/ComputeEnvOperationalSummaryTest.kt
@@ -80,7 +80,7 @@ class ComputeEnvOperationalSummaryTest {
             )
             val expected = mapOf(
                 "nbSurveillances" to 0,
-                "totalSurveillanceDurationInHours" to 0,
+                "totalSurveillanceDurationInHours" to 0.0,
                 "nbControls" to 0,
                 "nbInfractionsWithRecord" to 0,
                 "nbInfractionsWithoutRecord" to 0,
@@ -114,7 +114,7 @@ class ComputeEnvOperationalSummaryTest {
             )
             val expected = mapOf(
                 "nbSurveillances" to 2,
-                "totalSurveillanceDurationInHours" to 2,
+                "totalSurveillanceDurationInHours" to 2.0,
                 "nbControls" to 3,
                 "nbInfractionsWithRecord" to 1,
                 "nbInfractionsWithoutRecord" to 1,


### PR DESCRIPTION
Avec Quentin, on avait 2 fields à 2 endroits différent de l'API qui sont en fait les mêmes mais avec des valeurs différentes donc j'ai harmonisé et en fait là, on faisait une flooring conversion vers Int trop tôt 