### PR TITLE
feat: improve search establishment

### DIFF
--- a/frontend/src/v2/features/common/components/ui/search-establishment.tsx
+++ b/frontend/src/v2/features/common/components/ui/search-establishment.tsx
@@ -17,7 +17,8 @@ export const SearchEstablishment = styled(
     const [search, setSearch] = useState<string>()
     const { data: establishments } = useEstablishmentListQuery(search)
 
-    const getName = (value: Establishment) => `${value.name} | n°${value.siren} | ${value.address}`
+    const getName = (value: Establishment) =>
+      `${value.name} ${value.isHeadquarter ? `(siège) ` : ''}| SIRET=${value.siret} | ${value.address}`
 
     const onSelect = (eventKey?: string, event: SyntheticEvent) => {
       const value = establishments?.find(item => item.id === eventKey)

--- a/frontend/src/v2/features/common/services/__tests__/use-etablishments-service.test.tsx
+++ b/frontend/src/v2/features/common/services/__tests__/use-etablishments-service.test.tsx
@@ -34,7 +34,7 @@ describe('useEstablishmentListQuery', () => {
     expect(mockedAxios.get).not.toHaveBeenCalled()
   })
 
-  it('should fetch and transform results when search is 3+ characters', async () => {
+  it('should fetch and transform matching_etablissements', async () => {
     const apiResponse = {
       data: {
         results: [
@@ -48,7 +48,17 @@ describe('useEstablishmentListQuery', () => {
               geo_adresse: '1 rue test 75001 Paris',
               code_postal: '75001',
               libelle_commune: 'Paris'
-            }
+            },
+            matching_etablissements: [
+              {
+                adresse: '2 rue match',
+                siret: '12345678900002',
+                geo_adresse: '2 rue match 69001 Lyon',
+                code_postal: '69001',
+                libelle_commune: 'Lyon',
+                est_siege: false
+              }
+            ]
           }
         ]
       }
@@ -66,13 +76,111 @@ describe('useEstablishmentListQuery', () => {
       {
         country: 'France',
         siren: '123456789',
-        siret: '12345678900001',
-        city: 'Paris',
-        zipcode: '75001',
-        address: '1 rue test 75001 Paris',
-        name: 'Company RS'
+        siret: '12345678900002',
+        city: 'Lyon',
+        zipcode: '69001',
+        address: '2 rue match 69001 Lyon',
+        name: 'Company RS',
+        isHeadquarter: false
       }
     ])
+  })
+
+  it('should flatmap multiple matching_etablissements across results', async () => {
+    const apiResponse = {
+      data: {
+        results: [
+          {
+            siren: '111111111',
+            nom_complet: 'Multi Co',
+            nom_raison_sociale: 'Multi RS',
+            siege: {
+              adresse: 'siege addr',
+              siret: '11111111100000',
+              geo_adresse: 'siege geo',
+              code_postal: '75001',
+              libelle_commune: 'Paris'
+            },
+            matching_etablissements: [
+              {
+                adresse: 'addr1',
+                siret: '11111111100001',
+                geo_adresse: 'geo1',
+                code_postal: '75001',
+                libelle_commune: 'Paris',
+                est_siege: false
+              },
+              {
+                adresse: 'addr2',
+                siret: '11111111100002',
+                geo_adresse: 'geo2',
+                code_postal: '69001',
+                libelle_commune: 'Lyon',
+                est_siege: false
+              }
+            ]
+          }
+        ]
+      }
+    }
+    mockedAxios.get.mockResolvedValueOnce(apiResponse)
+
+    const { result } = renderHook(() => useEstablishmentListQuery('multi'), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.data?.[0]?.siret).toBe('11111111100001')
+    expect(result.current.data?.[1]?.siret).toBe('11111111100002')
+  })
+
+  it('should sort headquarters first within matching_etablissements', async () => {
+    const apiResponse = {
+      data: {
+        results: [
+          {
+            siren: '222222222',
+            nom_complet: 'Sort Co',
+            nom_raison_sociale: 'Sort RS',
+            siege: {
+              adresse: 'siege',
+              siret: '22222222200000',
+              geo_adresse: 'siege geo',
+              code_postal: '75001',
+              libelle_commune: 'Paris'
+            },
+            matching_etablissements: [
+              {
+                adresse: 'branch',
+                siret: '22222222200001',
+                geo_adresse: 'branch geo',
+                code_postal: '69001',
+                libelle_commune: 'Lyon',
+                est_siege: false
+              },
+              {
+                adresse: 'hq',
+                siret: '22222222200002',
+                geo_adresse: 'hq geo',
+                code_postal: '75001',
+                libelle_commune: 'Paris',
+                est_siege: true
+              }
+            ]
+          }
+        ]
+      }
+    }
+    mockedAxios.get.mockResolvedValueOnce(apiResponse)
+
+    const { result } = renderHook(() => useEstablishmentListQuery('sort'), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.[0]?.isHeadquarter).toBe(true)
+    expect(result.current.data?.[0]?.siret).toBe('22222222200002')
+    expect(result.current.data?.[1]?.isHeadquarter).toBe(false)
+    expect(result.current.data?.[1]?.siret).toBe('22222222200001')
   })
 
   it('should fallback to adresse when geo_adresse is null', async () => {
@@ -80,16 +188,26 @@ describe('useEstablishmentListQuery', () => {
       data: {
         results: [
           {
-            siren: '111111111',
+            siren: '333333333',
             nom_complet: 'Fallback Co',
             nom_raison_sociale: null,
             siege: {
-              adresse: '5 avenue fallback',
-              siret: '11111111100001',
-              geo_adresse: null,
-              code_postal: '69001',
-              libelle_commune: 'Lyon'
-            }
+              adresse: 'siege',
+              siret: '33333333300000',
+              geo_adresse: 'siege geo',
+              code_postal: '75001',
+              libelle_commune: 'Paris'
+            },
+            matching_etablissements: [
+              {
+                adresse: '5 avenue fallback',
+                siret: '33333333300001',
+                geo_adresse: null,
+                code_postal: '69001',
+                libelle_commune: 'Lyon',
+                est_siege: false
+              }
+            ]
           }
         ]
       }
@@ -103,14 +221,94 @@ describe('useEstablishmentListQuery', () => {
     expect(result.current.data).toEqual([
       {
         country: 'France',
-        siren: '111111111',
-        siret: '11111111100001',
+        siren: '333333333',
+        siret: '33333333300001',
         city: 'Lyon',
         zipcode: '69001',
         address: '5 avenue fallback',
-        name: 'Fallback Co'
+        name: 'Fallback Co',
+        isHeadquarter: false
       }
     ])
+  })
+
+  it('should fallback to siege when matching_etablissements is empty', async () => {
+    const apiResponse = {
+      data: {
+        results: [
+          {
+            siren: '555555555',
+            nom_complet: 'Siren Co',
+            nom_raison_sociale: 'Siren RS',
+            siege: {
+              adresse: '10 rue siege',
+              siret: '55555555500001',
+              geo_adresse: '10 rue siege 75001 Paris',
+              code_postal: '75001',
+              libelle_commune: 'Paris'
+            },
+            matching_etablissements: []
+          }
+        ]
+      }
+    }
+    mockedAxios.get.mockResolvedValueOnce(apiResponse)
+
+    const { result } = renderHook(() => useEstablishmentListQuery('siren'), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([
+      {
+        country: 'France',
+        siren: '555555555',
+        siret: '55555555500001',
+        city: 'Paris',
+        zipcode: '75001',
+        address: '10 rue siege 75001 Paris',
+        name: 'Siren RS',
+        isHeadquarter: undefined
+      }
+    ])
+  })
+
+  it('should filter out closed establishments', async () => {
+    const apiResponse = {
+      data: {
+        results: [
+          {
+            siren: '444444444',
+            nom_complet: 'Closed Co',
+            nom_raison_sociale: 'Closed RS',
+            date_fermeture: '2023-01-01',
+            siege: {
+              adresse: 'closed',
+              siret: '44444444400000',
+              geo_adresse: 'closed geo',
+              code_postal: '75001',
+              libelle_commune: 'Paris'
+            },
+            matching_etablissements: [
+              {
+                adresse: 'closed branch',
+                siret: '44444444400001',
+                geo_adresse: 'closed branch geo',
+                code_postal: '75001',
+                libelle_commune: 'Paris',
+                est_siege: false
+              }
+            ]
+          }
+        ]
+      }
+    }
+    mockedAxios.get.mockResolvedValueOnce(apiResponse)
+
+    const { result } = renderHook(() => useEstablishmentListQuery('closed'), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data).toEqual([])
   })
 })
 
@@ -135,7 +333,7 @@ describe('useLazyEstablishmentQuery', () => {
     expect(mockedAxios.get).not.toHaveBeenCalled()
   })
 
-  it('should fetch and return the first result', async () => {
+  it('should fetch and return the first result from matching_etablissements', async () => {
     const apiResponse = {
       data: {
         results: [
@@ -145,11 +343,21 @@ describe('useLazyEstablishmentQuery', () => {
             nom_raison_sociale: 'Single RS',
             siege: {
               adresse: '10 blvd test',
-              siret: '98765432100001',
+              siret: '98765432100000',
               geo_adresse: '10 blvd test 13001 Marseille',
               code_postal: '13001',
               libelle_commune: 'Marseille'
-            }
+            },
+            matching_etablissements: [
+              {
+                adresse: '20 blvd match',
+                siret: '98765432100001',
+                geo_adresse: '20 blvd match 13001 Marseille',
+                code_postal: '13001',
+                libelle_commune: 'Marseille',
+                est_siege: true
+              }
+            ]
           }
         ]
       }
@@ -169,8 +377,9 @@ describe('useLazyEstablishmentQuery', () => {
       siret: '98765432100001',
       city: 'Marseille',
       zipcode: '13001',
-      address: '10 blvd test 13001 Marseille',
-      name: 'Single RS'
+      address: '20 blvd match 13001 Marseille',
+      name: 'Single RS',
+      isHeadquarter: true
     })
   })
 

--- a/frontend/src/v2/features/common/services/use-etablishments-service.tsx
+++ b/frontend/src/v2/features/common/services/use-etablishments-service.tsx
@@ -8,24 +8,44 @@ interface SearchEstablishment {
   siren: string
   nom_complet: string
   nom_raison_sociale: string
+  date_fermeture?: string | null
   siege: {
     adresse: string
     siret: string
     geo_adresse: string
     code_postal: string
     libelle_commune: string
+    est_siege?: boolean
   }
+  matching_etablissements: {
+    adresse: string
+    siret: string
+    geo_adresse: string
+    code_postal: string
+    libelle_commune: string
+    est_siege?: boolean
+  }[]
 }
 
-const transform = (value: SearchEstablishment) => ({
-  country: 'France',
-  siren: value?.siren,
-  siret: value?.siege?.siret,
-  city: value.siege.libelle_commune,
-  zipcode: value?.siege?.code_postal,
-  address: value?.siege?.geo_adresse ?? value?.siege?.adresse,
-  name: value.nom_raison_sociale ?? value.nom_complet
-})
+const filter = (value: SearchEstablishment) => {
+  return value.date_fermeture === null || value.date_fermeture === undefined
+}
+
+const transform = (value: SearchEstablishment): Establishment[] => {
+  const etablissements = value.matching_etablissements?.length > 0 ? value.matching_etablissements : [value.siege]
+  return etablissements
+    .map(etablissement => ({
+      country: 'France',
+      siren: value?.siren,
+      siret: etablissement.siret,
+      city: etablissement.libelle_commune,
+      zipcode: etablissement.code_postal,
+      address: etablissement.geo_adresse ?? etablissement.adresse,
+      name: value.nom_raison_sociale ?? value.nom_complet,
+      isHeadquarter: etablissement.est_siege
+    }))
+    .sort((a, b) => (b.isHeadquarter ? 1 : 0) - (a.isHeadquarter ? 1 : 0))
+}
 
 export const useEstablishmentListQuery = (search?: string) => {
   const fetchEtablishments = (): Promise<SearchEstablishment[]> =>
@@ -35,7 +55,8 @@ export const useEstablishmentListQuery = (search?: string) => {
     queryKey: ['establishments', search],
     queryFn:
       search && search.length >= 3
-        ? () => fetchEtablishments().then(data => data.map(value => transform(value)))
+        ? () =>
+            fetchEtablishments().then(data => data.filter(value => filter(value)).flatMap(value => transform(value)))
         : skipToken
   })
   return query
@@ -50,7 +71,7 @@ export const useLazyEstablishmentQuery = (siren?: string) => {
     queryFn: siren
       ? () =>
           fetchEtablishment()
-            .then(data => data.map(value => transform(value)))
+            .then(data => data.flatMap(value => transform(value)))
             .then(data => (data.length > 0 ? data[0] : undefined)) as Promise<Establishment>
       : skipToken
   })

--- a/frontend/src/v2/features/common/types/etablishment.ts
+++ b/frontend/src/v2/features/common/types/etablishment.ts
@@ -8,4 +8,5 @@ export interface Establishment {
   country?: string
   zipcode?: string
   isForeign?: boolean
+  isHeadquarter?: boolean
 }


### PR DESCRIPTION
La nouvelle logique, c'est d'utiliser le champs `matching_establishments` si présent, sinon fallback sur 'siege'

Le display dans le dropdown a aussi été changé