### PR TITLE
chore: split backend config, exclude it fro coverage

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/config/SecurityConfig.kt
@@ -1,5 +1,8 @@
 package fr.gouv.dgampa.rapportnav.config
 
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.CustomAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.SentryUserContextFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.user.AuthoritiesEnum
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/CreateUser.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/CreateUser.kt
@@ -1,6 +1,6 @@
 package fr.gouv.dgampa.rapportnav.domain.use_cases.user
 
-import fr.gouv.dgampa.rapportnav.config.PasswordValidator
+import fr.gouv.dgampa.rapportnav.domain.utils.PasswordValidator
 import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/UpdateUserPassword.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/use_cases/user/UpdateUserPassword.kt
@@ -1,6 +1,6 @@
 package fr.gouv.dgampa.rapportnav.domain.use_cases.user
 
-import fr.gouv.dgampa.rapportnav.config.PasswordValidator
+import fr.gouv.dgampa.rapportnav.domain.utils.PasswordValidator
 import fr.gouv.dgampa.rapportnav.config.UseCase
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode.COULD_NOT_FIND_EXCEPTION

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/utils/PasswordValidator.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/domain/utils/PasswordValidator.kt
@@ -1,4 +1,4 @@
-package fr.gouv.dgampa.rapportnav.config
+package fr.gouv.dgampa.rapportnav.domain.utils
 
 object PasswordValidator {
     private val pattern = Regex(

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/auth/ApiAuthController.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/auth/ApiAuthController.kt
@@ -1,6 +1,6 @@
 package fr.gouv.dgampa.rapportnav.infrastructure.api.auth
 
-import fr.gouv.dgampa.rapportnav.config.PasswordValidator
+import fr.gouv.dgampa.rapportnav.domain.utils.PasswordValidator
 import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode.*
@@ -78,6 +78,7 @@ class ApiAuthController(
         val ipAddress = HttpRequestUtils.getClientIp(request)
         val userAgent = HttpRequestUtils.getUserAgent(request)
         val email = body.email.trim()
+        val loginFailedMessage = "Login failed"
 
         if (body.email.isEmpty() || body.password.isEmpty()) {
             logAuthenticationAudit.logLoginFailure(
@@ -102,7 +103,7 @@ class ApiAuthController(
             )
             throw BackendUsageException(
                 code = INCORRECT_USER_IDENTIFIER_EXCEPTION,
-                message = "Login failed "
+                message = loginFailedMessage
             )
         }
 
@@ -115,14 +116,14 @@ class ApiAuthController(
             )
             throw BackendUsageException(
                 code = INCORRECT_USER_IDENTIFIER_EXCEPTION,
-                message = "Login failed "
+                message = loginFailedMessage
             )
         }
 
             if (user.disabledAt != null) {
             throw BackendUsageException(
                 code = USER_ACCOUNT_DISABLED_EXCEPTION,
-                message = "Login failed "
+                message = loginFailedMessage
             )
         }
 

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/filter/ApiKeyAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/filter/ApiKeyAuthenticationFilter.kt
@@ -1,4 +1,4 @@
-package fr.gouv.dgampa.rapportnav.config
+package fr.gouv.dgampa.rapportnav.infrastructure.api.filter
 
 import fr.gouv.dgampa.rapportnav.domain.use_cases.apikey.RateLimitException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.apikey.ValidateApiKey

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/filter/CustomAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/filter/CustomAuthenticationFilter.kt
@@ -1,4 +1,4 @@
-package fr.gouv.dgampa.rapportnav.config
+package fr.gouv.dgampa.rapportnav.infrastructure.api.filter
 
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import jakarta.servlet.FilterChain

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/filter/SentryUserContextFilter.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/api/filter/SentryUserContextFilter.kt
@@ -1,4 +1,4 @@
-package fr.gouv.dgampa.rapportnav.config
+package fr.gouv.dgampa.rapportnav.infrastructure.api.filter
 
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import io.sentry.Sentry

--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/AuditorAwareImpl.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/AuditorAwareImpl.kt
@@ -1,4 +1,4 @@
-package fr.gouv.dgampa.rapportnav.config
+package fr.gouv.dgampa.rapportnav.infrastructure.database
 
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import org.springframework.data.domain.AuditorAware

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/AdminApiKeyAuthenticationFilterTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/AdminApiKeyAuthenticationFilterTest.kt
@@ -1,6 +1,6 @@
 package fr.gouv.gmampa.rapportnav.config
 
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.apikey.ApiKeyEntity
 import fr.gouv.dgampa.rapportnav.domain.use_cases.apikey.RateLimitException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.apikey.ValidateApiKey

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/AuditorAwareImplTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/AuditorAwareImplTest.kt
@@ -1,6 +1,6 @@
 package fr.gouv.gmampa.rapportnav.config
 
-import fr.gouv.dgampa.rapportnav.config.AuditorAwareImpl
+import fr.gouv.dgampa.rapportnav.infrastructure.database.AuditorAwareImpl
 import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import org.junit.jupiter.api.AfterEach

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/CustomAuthenticationFilterTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/CustomAuthenticationFilterTest.kt
@@ -1,6 +1,6 @@
 package fr.gouv.gmampa.rapportnav.config
 
-import fr.gouv.dgampa.rapportnav.config.CustomAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.CustomAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/PasswordValidatorTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/PasswordValidatorTest.kt
@@ -1,6 +1,6 @@
 package fr.gouv.gmampa.rapportnav.config
 
-import fr.gouv.dgampa.rapportnav.config.PasswordValidator
+import fr.gouv.dgampa.rapportnav.domain.utils.PasswordValidator
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/SecurityConfigTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/SecurityConfigTest.kt
@@ -1,10 +1,9 @@
 package fr.gouv.gmampa.rapportnav.config
 
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
-import fr.gouv.dgampa.rapportnav.config.CustomAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.CustomAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.config.SecurityConfig
-import fr.gouv.dgampa.rapportnav.config.SentryUserContextFilter
-import fr.gouv.dgampa.rapportnav.domain.entities.user.AuthoritiesEnum
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.SentryUserContextFilter
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -117,14 +116,14 @@ class SecurityConfigTest {
     @Test
     fun `apiKeySecurityFilter should have Bean annotation`() {
         val method = SecurityConfig::class.java.getMethod("apiKeySecurityFilter", HttpSecurity::class.java)
-        val beanAnnotation = method.getAnnotation(org.springframework.context.annotation.Bean::class.java)
+        val beanAnnotation = method.getAnnotation(Bean::class.java)
         assertNotNull(beanAnnotation)
     }
 
     @Test
     fun `filterChain should have Bean annotation`() {
         val method = SecurityConfig::class.java.getMethod("filterChain", HttpSecurity::class.java)
-        val beanAnnotation = method.getAnnotation(org.springframework.context.annotation.Bean::class.java)
+        val beanAnnotation = method.getAnnotation(Bean::class.java)
         assertNotNull(beanAnnotation)
     }
 }

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/SentryUserContextFilterTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/config/SentryUserContextFilterTest.kt
@@ -1,6 +1,6 @@
 package fr.gouv.gmampa.rapportnav.config
 
-import fr.gouv.dgampa.rapportnav.config.SentryUserContextFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.SentryUserContextFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.user.RoleTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.user.User
 import io.sentry.Sentry

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/UserAdminControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/api/admin/UserAdminControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.api.admin
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.GetAuthenticationAuditList
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.*

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AdministrationControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AdministrationControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.administrations.GetAdministrationById
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.administrations.GetAdministrations

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRestControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.AgentEntity
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetCrewByServiceId

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRoleControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/AgentRoleControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.crew.AgentRoleEntity
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.crew.GetAgentRoles

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/ControlUnitResourceRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/ControlUnitResourceRestControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.controlUnitResource.GetControlUnitResources

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/FishAuctionControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/FishAuctionControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.fish.FacadeTypeEnum
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.fish.FishAuctionEntity
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/MissionRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/MissionRestControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.config.JacksonConfig
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageErrorCode
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendUsageException

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/NatInfRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/NatInfRestControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.entities.mission.nav.infraction.NatinfEntity
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/PortRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/PortRestControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetPorts

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/UserRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/UserRestControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.service.GetServiceById
 import fr.gouv.dgampa.rapportnav.domain.use_cases.user.FindById

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/VesselRestControllerTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/bff/controllers/VesselRestControllerTest.kt
@@ -1,7 +1,7 @@
 package fr.gouv.gmampa.rapportnav.infrastructure.bff.controllers
 
 import fr.gouv.dgampa.rapportnav.RapportNavApplication
-import fr.gouv.dgampa.rapportnav.config.ApiKeyAuthenticationFilter
+import fr.gouv.dgampa.rapportnav.infrastructure.api.filter.ApiKeyAuthenticationFilter
 import fr.gouv.dgampa.rapportnav.domain.exceptions.BackendInternalException
 import fr.gouv.dgampa.rapportnav.domain.use_cases.auth.TokenService
 import fr.gouv.dgampa.rapportnav.domain.use_cases.mission.v2.GetVessels

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,3 +22,7 @@ sonar.exclusions=\
   backend/target/**,\
   backend/gradle/**,\
   backend/.gradle/**
+
+# Exclude config folder from test coverage (pure Spring wiring, no testable logic)
+sonar.coverage.exclusions=\
+  **/rapportnav/config/**


### PR DESCRIPTION
Petite amélioration pour le test coverage du backend. On avait trop de trucs differents dans le dossier config du backend donc j'ai splitté et exclut les fichiers que ca sert à rien de tester du coverage