### PR TITLE
feat(e2e): introduce e2e tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@ include:
   - /.gitlab-ci/jobs/build_projet_gradle.yml
   - /.gitlab-ci/jobs/build_projet_npm.yml
   - /.gitlab-ci/jobs/construction_image.yml
+  - /.gitlab-ci/jobs/test_e2e.yml
   - /.gitlab-ci/jobs/analyse_sonar.yml
   - /.gitlab-ci/jobs/analyse_trivy.yml
   - /.gitlab-ci/jobs/analyse_dependency-check.yml

--- a/.gitlab-ci/jobs/test_e2e.yml
+++ b/.gitlab-ci/jobs/test_e2e.yml
@@ -1,0 +1,34 @@
+test_e2e:
+  rules:
+    - if: '$ENV_DEPLOIEMENT == "ecole" || $ENV_DEPLOIEMENT == "integration"'
+      when: always
+  stage: test
+  image: mcr.microsoft.com/playwright:v1.52.0-noble
+  allow_failure: true
+  variables:
+    CI: 'true'
+  script:
+    - cd frontend
+    - cp .env.example .env
+    - npm ci --cache ${CI_PROJECT_DIR}/.npm
+    - npx playwright test --config e2e/playwright.config.ts
+  cache:
+    key:
+      prefix: npm
+      files:
+        - frontend/package-lock.json
+    paths:
+      - .npm/
+    when: always
+    policy: pull
+  artifacts:
+    name: 'E2E test results from $CI_PROJECT_NAME on $CI_COMMIT_REF_SLUG'
+    expire_in: 12 hours
+    when: always
+    paths:
+      - frontend/playwright-report/
+      - frontend/test-results/
+    reports:
+      junit: frontend/e2e-results.xml
+  tags:
+    - selfservice

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,6 +22,8 @@ yarn-error.log*
 
 # testing
 /coverage
+/test-results
+/playwright-report
 
 # production
 /build

--- a/frontend/e2e/fixtures/auth.ts
+++ b/frontend/e2e/fixtures/auth.ts
@@ -1,0 +1,46 @@
+import { test as base, Page } from '@playwright/test'
+import { createTestJwt } from '../helpers/jwt'
+import { clearQueryCache, mockApiCatchAll, mockPamUser, mockStaticData, mockUlamUser } from '../helpers/mock-api'
+
+type AuthFixtures = {
+  pamPage: Page
+  ulamPage: Page
+}
+
+async function createAuthContext(browser: any, userId: number, roles: string[]): Promise<{ context: any; page: Page }> {
+  const context = await browser.newContext({
+    storageState: {
+      cookies: [{ name: 'XSRF-TOKEN', value: 'test-csrf', domain: 'localhost', path: '/' }],
+      origins: [
+        {
+          origin: 'http://localhost:5173',
+          localStorage: [{ name: 'jwt', value: createTestJwt({ userId, roles }) }]
+        }
+      ]
+    }
+  })
+  const page = await context.newPage()
+  await clearQueryCache(page)
+  await mockStaticData(page)
+  return { context, page }
+}
+
+export const test = base.extend<AuthFixtures>({
+  pamPage: async ({ browser }, use) => {
+    const { context, page } = await createAuthContext(browser, 1, ['USER_PAM'])
+    await mockPamUser(page)
+    await mockApiCatchAll(page)
+    await use(page)
+    await context.close()
+  },
+
+  ulamPage: async ({ browser }, use) => {
+    const { context, page } = await createAuthContext(browser, 2, ['USER_ULAM'])
+    await mockUlamUser(page)
+    await mockApiCatchAll(page)
+    await use(page)
+    await context.close()
+  }
+})
+
+export { expect } from '@playwright/test'

--- a/frontend/e2e/fixtures/data/mission-detail-ulam.json
+++ b/frontend/e2e/fixtures/data/mission-detail-ulam.json
@@ -1,0 +1,36 @@
+{
+  "id": 201,
+  "idUUID": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "IN_PROGRESS",
+  "isCompleteForStats": false,
+  "data": {
+    "startDateTimeUtc": "2026-01-15T07:00:00Z",
+    "endDateTimeUtc": "2026-01-15T19:00:00Z",
+    "missionSource": "RAPPORT_NAV",
+    "missionTypes": ["LAND"],
+    "openBy": "ULAM Test Service",
+    "controlUnits": [
+      {
+        "id": 200,
+        "name": "ULAM Test Unit",
+        "administration": "DIRM SA",
+        "isArchived": false,
+        "resources": []
+      }
+    ],
+    "facade": "SA",
+    "hasMissionOrder": false,
+    "isUnderJdp": false
+  },
+  "generalInfos": {
+    "missionTypes": ["LAND"],
+    "missionReportType": "FIELD_REPORT",
+    "crew": [],
+    "nbHourAtSea": 0
+  },
+  "actions": [],
+  "completenessForStats": {
+    "status": "INCOMPLETE",
+    "sources": ["RAPPORT_NAV"]
+  }
+}

--- a/frontend/e2e/fixtures/data/user-pam.json
+++ b/frontend/e2e/fixtures/data/user-pam.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "email": "pam-user@test.gouv.fr",
+  "firstName": "Jean",
+  "lastName": "Dupont",
+  "serviceId": 10,
+  "serviceName": "PAM Test Service",
+  "controlUnitId": 100
+}

--- a/frontend/e2e/fixtures/data/user-ulam.json
+++ b/frontend/e2e/fixtures/data/user-ulam.json
@@ -1,0 +1,9 @@
+{
+  "id": 2,
+  "email": "ulam-user@test.gouv.fr",
+  "firstName": "Marie",
+  "lastName": "Martin",
+  "serviceId": 20,
+  "serviceName": "ULAM Test Service",
+  "controlUnitId": 200
+}

--- a/frontend/e2e/helpers/jwt.ts
+++ b/frontend/e2e/helpers/jwt.ts
@@ -1,0 +1,30 @@
+/** URL-safe Base64 encoding as required by JWT spec (RFC 7519) */
+function base64url(str: string): string {
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+}
+
+/** Creates a test JWT token that jwt-decode can parse. No signature verification on frontend. */
+export function createTestJwt(payload: { userId: number; roles: string[] }): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const body = base64url(
+    JSON.stringify({
+      ...payload,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000)
+    })
+  )
+  return `${header}.${body}.${base64url('fake-signature')}`
+}
+
+/** Creates an expired JWT for testing auth expiry scenarios */
+export function createExpiredTestJwt(payload: { userId: number; roles: string[] }): string {
+  const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const body = base64url(
+    JSON.stringify({
+      ...payload,
+      exp: Math.floor(Date.now() / 1000) - 3600,
+      iat: Math.floor(Date.now() / 1000) - 7200
+    })
+  )
+  return `${header}.${body}.${base64url('fake-signature')}`
+}

--- a/frontend/e2e/helpers/mock-api.ts
+++ b/frontend/e2e/helpers/mock-api.ts
@@ -1,0 +1,99 @@
+import { Page } from '@playwright/test'
+import userPam from '../fixtures/data/user-pam.json' with { type: 'json' }
+import userUlam from '../fixtures/data/user-ulam.json' with { type: 'json' }
+
+/**
+ * Mock all static data endpoints that the app prefetches via usePrefetchStaticData.
+ * Uses the actual endpoint names from the source code (agent_roles with underscore, etc.).
+ */
+export async function mockStaticData(page: Page) {
+  const staticEndpoints = [
+    '**/api/v2/agents',
+    '**/api/v2/agent_roles',
+    '**/api/v2/administrations',
+    '**/api/v2/resources',
+    '**/api/v2/natinfs',
+    '**/api/v2/ports',
+    '**/api/v2/fish-auctions'
+  ]
+  for (const pattern of staticEndpoints) {
+    await page.route(pattern, (route) => route.fulfill({ body: '[]', contentType: 'application/json' }))
+  }
+}
+
+/** Mock the user endpoint for a PAM user */
+export async function mockPamUser(page: Page) {
+  await page.route('**/api/v2/users/*', (route) =>
+    route.fulfill({ body: JSON.stringify(userPam), contentType: 'application/json' })
+  )
+}
+
+/** Mock the user endpoint for a ULAM user */
+export async function mockUlamUser(page: Page) {
+  await page.route('**/api/v2/users/*', (route) =>
+    route.fulfill({ body: JSON.stringify(userUlam), contentType: 'application/json' })
+  )
+}
+
+/** Mock the user endpoint for an admin user */
+export async function mockAdminUser(page: Page) {
+  await page.route('**/api/v2/users/*', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 3, email: 'admin@test.gouv.fr', firstName: 'Admin', lastName: 'User', serviceId: 30 })
+    })
+  )
+}
+
+/** Mock the missions list endpoint */
+export async function mockMissionList(page: Page, missions: unknown[] = []) {
+  await page.route('**/api/v2/missions?**', (route) =>
+    route.fulfill({ body: JSON.stringify(missions), contentType: 'application/json' })
+  )
+}
+
+/** Mock the inquiries list endpoint */
+export async function mockInquiryList(page: Page, inquiries: unknown[] = []) {
+  await page.route('**/api/v2/inquiries?**', (route) =>
+    route.fulfill({ body: JSON.stringify(inquiries), contentType: 'application/json' })
+  )
+}
+
+/** Mock POST for mission creation (ULAM) */
+export async function mockCreateMission(page: Page, response: Record<string, unknown> = { id: 999 }) {
+  await page.route('**/api/v2/missions', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({ body: JSON.stringify(response), contentType: 'application/json', status: 201 })
+    }
+    return route.continue()
+  })
+}
+
+/**
+ * Catch-all for any /api/ request not already handled by a more specific route.
+ * Logs the URL to help debug missing mocks, then returns an empty array.
+ * Must be registered LAST (Playwright matches routes in reverse registration order).
+ */
+export async function mockApiCatchAll(page: Page) {
+  await page.route('**/api/**', (route) => {
+    if (process.env.DEBUG_MOCKS) {
+      console.warn(`[e2e] Unmocked API call: ${route.request().method()} ${route.request().url()}`)
+    }
+    route.fulfill({ body: '[]', contentType: 'application/json' })
+  })
+}
+
+/**
+ * Clear React Query persisted cache to prevent stale data between tests.
+ * Must be called before navigating to any page.
+ */
+export async function clearQueryCache(page: Page) {
+  await page.addInitScript(() => {
+    const keys = Object.keys(localStorage)
+    for (const key of keys) {
+      if (key.startsWith('REACT_QUERY')) {
+        localStorage.removeItem(key)
+      }
+    }
+  })
+}

--- a/frontend/e2e/playwright.config.ts
+++ b/frontend/e2e/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['junit', { outputFile: 'e2e-results.xml' }], ['html', { open: 'never' }]]
+    : 'html',
+
+  expect: {
+    timeout: 10000
+  },
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    locale: 'fr-FR',
+    timezoneId: 'Europe/Paris'
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60000
+  }
+})

--- a/frontend/e2e/tests/auth/login.spec.ts
+++ b/frontend/e2e/tests/auth/login.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test'
+import { createTestJwt } from '../../helpers/jwt'
+import { mockApiCatchAll } from '../../helpers/mock-api'
+
+/** Set up all post-login API mocks needed for the redirect chain to complete.
+ *  Catch-all registered FIRST so that more specific routes (registered after) take precedence. */
+async function mockPostLoginApis(page: import('@playwright/test').Page, user: Record<string, unknown>) {
+  await mockApiCatchAll(page)
+  await page.route('**/api/v2/users/*', (route) =>
+    route.fulfill({ contentType: 'application/json', body: JSON.stringify(user) })
+  )
+}
+
+test.describe('Login redirect chain', () => {
+  test('PAM user: login -> / -> /pam/missions', async ({ page }) => {
+    const token = createTestJwt({ userId: 1, roles: ['USER_PAM'] })
+
+    await mockPostLoginApis(page, {
+      id: 1, email: 'pam@test.gouv.fr', firstName: 'Jean', lastName: 'Dupont', serviceId: 10
+    })
+    await page.route('**/api/v1/auth/login', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ token }) })
+    )
+
+    await page.goto('/login', { waitUntil: 'networkidle' })
+    await page.getByLabel('Email').fill('pam@test.gouv.fr')
+    await page.getByLabel('Mot de passe').fill('password123')
+    await page.getByRole('button', { name: 'Se connecter' }).click()
+
+    await expect(page).toHaveURL(/\/pam\/missions/, { timeout: 10000 })
+    await expect(page.getByText('Mes rapports')).toBeVisible()
+  })
+
+  test('ULAM user: login -> / -> /ulam/missions', async ({ page }) => {
+    const token = createTestJwt({ userId: 2, roles: ['USER_ULAM'] })
+
+    await mockPostLoginApis(page, {
+      id: 2, email: 'ulam@test.gouv.fr', firstName: 'Marie', lastName: 'Martin', serviceId: 20
+    })
+    await page.route('**/api/v1/auth/login', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ token }) })
+    )
+
+    await page.goto('/login', { waitUntil: 'networkidle' })
+    await page.getByLabel('Email').fill('ulam@test.gouv.fr')
+    await page.getByLabel('Mot de passe').fill('password123')
+    await page.getByRole('button', { name: 'Se connecter' }).click()
+
+    await expect(page).toHaveURL(/\/ulam\/missions/, { timeout: 10000 })
+    await expect(page.getByText('Mes rapports journaliers')).toBeVisible()
+  })
+})

--- a/frontend/e2e/tests/ulam/create-action.spec.ts
+++ b/frontend/e2e/tests/ulam/create-action.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '../../fixtures/auth'
+import missionDetail from '../../fixtures/data/mission-detail-ulam.json' with { type: 'json' }
+
+test.describe('ULAM Create Action on Mission Page', () => {
+  test('should add a NOTE action and navigate to it', async ({ ulamPage: page }) => {
+    const actionId = 'action-note-001'
+
+    const noteAction = {
+      id: actionId,
+      actionType: 'NOTE',
+      source: 'RAPPORT_NAV',
+      data: {
+        startDateTimeUtc: '2026-01-15T10:30:00Z',
+        endDateTimeUtc: '2026-01-15T10:30:00Z',
+        observations: '',
+        isWithinDepartment: true
+      },
+      missionId: 201,
+      controlsToComplete: [],
+      completenessForStats: {},
+      sourcesOfMissingDataForStats: []
+    }
+
+    // Mock GET /missions/{id} — starts with no actions
+    await page.route('**/api/v2/missions/201', (route) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify(missionDetail) })
+    )
+
+    // Mock POST /owners/{id}/actions — returns the created note action
+    await page.route('**/api/v2/owners/*/actions', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify(noteAction)
+        })
+      }
+      return route.continue()
+    })
+
+    // Mock GET /owners/{id}/actions/{actionId} — action detail
+    await page.route('**/api/v2/owners/*/actions/*', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(noteAction)
+        })
+      }
+      return route.continue()
+    })
+
+    // Navigate to mission detail page
+    await page.goto('/ulam/missions/201', { waitUntil: 'networkidle' })
+
+    // Verify timeline header is visible
+    await expect(page.getByText('Actions réalisées en mission')).toBeVisible({ timeout: 10000 })
+
+    // Click "Ajouter" dropdown button (exact match to avoid "Ajouter un moyen" etc.)
+    await page.getByRole('button', { name: 'Ajouter', exact: true }).click()
+
+    // The dropdown should open — click "Ajouter une note libre"
+    await page.getByText('Ajouter une note libre').click()
+
+    // Should navigate to the action URL (missionId/actionId)
+    await expect(page).toHaveURL(/\/ulam\/missions\/201\//, { timeout: 10000 })
+  })
+})

--- a/frontend/e2e/tests/ulam/create-mission.spec.ts
+++ b/frontend/e2e/tests/ulam/create-mission.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../../fixtures/auth'
+import { mockMissionList } from '../../helpers/mock-api'
+import missionDetail from '../../fixtures/data/mission-detail-ulam.json' with { type: 'json' }
+
+test.describe('ULAM Create Mission', () => {
+  test('should open create dialog with conditional form fields', async ({ ulamPage: page }) => {
+    await mockMissionList(page, [])
+
+    await page.goto('/ulam/missions', { waitUntil: 'networkidle' })
+    await expect(page.getByText('Mes rapports journaliers')).toBeVisible({ timeout: 10000 })
+
+    // Open create dialog
+    await page.getByRole('button', { name: /Créer un rapport de mission/ }).click()
+    await expect(page.getByText("Création d'un rapport")).toBeVisible({ timeout: 5000 })
+
+    // Select "Rapport avec sortie terrain" → should show mission type checkboxes
+    await page.getByText('Sélectionner').first().click()
+    await page.getByText('Rapport avec sortie terrain').click()
+
+    // Verify conditional fields appeared
+    await expect(page.getByText('Type de mission', { exact: true })).toBeVisible()
+
+    // Close dialog
+    await page.locator('[data-testid="close-create-mission-icon"]').click()
+    await expect(page.getByText("Création d'un rapport")).not.toBeVisible()
+  })
+
+  test('should load mission detail page', async ({ ulamPage: page }) => {
+    await page.route('**/api/v2/missions/201', (route) =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify(missionDetail) })
+    )
+
+    await page.goto('/ulam/missions/201', { waitUntil: 'networkidle' })
+
+    // Verify the 3 main sections of mission detail
+    await expect(page.getByText('Informations générales')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('Actions réalisées en mission')).toBeVisible()
+  })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.81.6",
+  "version": "2.83.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.81.6",
+      "version": "2.83.0",
       "dependencies": {
         "@date-fns/utc": "^2.1.1",
         "@mtes-mct/monitor-ui": "^24.51.1",
@@ -37,6 +37,7 @@
         "@import-meta-env/cli": "^0.7.4",
         "@import-meta-env/prepare": "^0.2.3",
         "@import-meta-env/unplugin": "^0.6.2",
+        "@playwright/test": "^1.60.0",
         "@tanstack/react-query-devtools": "^5.83.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -3661,6 +3662,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -13931,6 +13948,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,10 @@
     "test:watch": "vitest src",
     "test:coverage": "vitest run --coverage",
     "snapshots": "vitest -u",
-    "docs": "docsify serve docs"
+    "docs": "docsify serve docs",
+    "test:e2e": "playwright test --config e2e/playwright.config.ts",
+    "test:e2e:ui": "playwright test --config e2e/playwright.config.ts --ui",
+    "test:e2e:debug": "playwright test --config e2e/playwright.config.ts --debug"
   },
   "dependencies": {
     "@date-fns/utc": "^2.1.1",
@@ -50,6 +53,7 @@
     "@import-meta-env/cli": "^0.7.4",
     "@import-meta-env/prepare": "^0.2.3",
     "@import-meta-env/unplugin": "^0.6.2",
+    "@playwright/test": "^1.60.0",
     "@tanstack/react-query-devtools": "^5.83.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/frontend/src/v2/pages/__tests__/inquiry-list-page.test.tsx
+++ b/frontend/src/v2/pages/__tests__/inquiry-list-page.test.tsx
@@ -1,0 +1,59 @@
+import { vi } from 'vitest'
+import { render, screen } from '../../../test-utils.tsx'
+import InquiryListPage from '../inquiry-list-page.tsx'
+import useInquiriesQuery from '../../features/inquiry/services/use-inquiries.tsx'
+import useCreateInquiryMutation from '../../features/inquiry/services/use-create-inquiry.tsx'
+
+vi.mock('../../features/inquiry/services/use-inquiries.tsx', () => ({
+  default: vi.fn()
+}))
+
+vi.mock('../../features/inquiry/services/use-create-inquiry.tsx', () => ({
+  default: vi.fn()
+}))
+
+describe('InquiryListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(useInquiriesQuery).mockReturnValue({
+      isLoading: false,
+      data: []
+    } as any)
+
+    vi.mocked(useCreateInquiryMutation).mockReturnValue({
+      mutateAsync: vi.fn()
+    } as any)
+  })
+
+  it('should render page title', () => {
+    render(<InquiryListPage />)
+    expect(
+      screen.getByText('Mes contrôles croisés (vérifications post contrôle terrain et enquêtes)')
+    ).toBeInTheDocument()
+  })
+
+  it('should render create inquiry button', () => {
+    render(<InquiryListPage />)
+    expect(screen.getByText('Créer un contrôle croisé')).toBeInTheDocument()
+  })
+
+  it('should show empty state when no inquiries', () => {
+    render(<InquiryListPage />)
+    expect(screen.getByText('Aucune mission pour cette période de temps.')).toBeInTheDocument()
+  })
+
+  it('should show loading state', () => {
+    vi.mocked(useInquiriesQuery).mockReturnValue({
+      isLoading: true,
+      data: undefined
+    } as any)
+    render(<InquiryListPage />)
+    expect(screen.getByTestId('mission-list-loader')).toBeInTheDocument()
+  })
+
+  it('should render date range navigator with year timeframe', () => {
+    render(<InquiryListPage />)
+    expect(screen.getByTestId('date-range-navigator')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/v2/pages/__tests__/mission-list-ulam-page.test.tsx
+++ b/frontend/src/v2/pages/__tests__/mission-list-ulam-page.test.tsx
@@ -1,0 +1,77 @@
+import { vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '../../../test-utils.tsx'
+import MissionListUlamPage from '../mission-list-ulam-page.tsx'
+import { useMissionList } from '../../features/common/hooks/use-mission-list.tsx'
+import useMissionsQuery from '../../features/common/services/use-missions.tsx'
+
+vi.mock('../../features/common/hooks/use-mission-list.tsx', () => ({
+  useMissionList: vi.fn()
+}))
+
+vi.mock('../../features/common/services/use-missions.tsx', () => ({
+  default: vi.fn()
+}))
+
+vi.mock('../../features/ulam/components/element/mission-create-dialog.tsx', () => ({
+  default: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? (
+      <div data-testid="create-dialog">
+        <button onClick={onClose}>close</button>
+      </div>
+    ) : null
+}))
+
+describe('MissionListUlamPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(useMissionList).mockReturnValue({
+      getMissionListItem: vi.fn((m) => ({ ...m, listItem: true }))
+    })
+
+    vi.mocked(useMissionsQuery).mockReturnValue({
+      isLoading: false,
+      data: []
+    } as any)
+  })
+
+  it('should render page title', () => {
+    render(<MissionListUlamPage />)
+    expect(screen.getByText('Mes rapports journaliers')).toBeInTheDocument()
+  })
+
+  it('should render create mission button', () => {
+    render(<MissionListUlamPage />)
+    expect(screen.getByText('Créer un rapport de mission')).toBeInTheDocument()
+  })
+
+  it('should open create dialog when button is clicked', async () => {
+    render(<MissionListUlamPage />)
+    expect(screen.queryByTestId('create-dialog')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Créer un rapport de mission'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('create-dialog')).toBeInTheDocument()
+    })
+  })
+
+  it('should show empty state when no missions', () => {
+    render(<MissionListUlamPage />)
+    expect(screen.getByText('Aucune mission pour cette période de temps.')).toBeInTheDocument()
+  })
+
+  it('should show loading state', () => {
+    vi.mocked(useMissionsQuery).mockReturnValue({
+      isLoading: true,
+      data: undefined
+    } as any)
+    render(<MissionListUlamPage />)
+    expect(screen.getByTestId('mission-list-loader')).toBeInTheDocument()
+  })
+
+  it('should render date range navigator with month timeframe', () => {
+    render(<MissionListUlamPage />)
+    expect(screen.getByTestId('date-range-navigator')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
J'ai lancé Claude sur un setup de tests e2e.
Il a réussi un truc mais s'est un peu emballé donc j'ai du le recadrer pour pas overengineer des trucs ou des trucs deja couverts pas des tests unit/integration

Par contre, c'est du mock e2e et pas du vrai full e2e parce qu'on a pas de server backend pour nos tests. C'est pas suffisant mais ca nous rajoute deja une couche de tests supplémentaires :
- unit (les fonctions)
- integration (des components, des pages)
- mock e2e (en gros le cablage entre les pages mais sans le vrai server)
- full e2e (ce qui nous manque avec le server)