### PR TITLE
fix: prevent duplicate Targets

### DIFF
--- a/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPATargetRepository.kt
+++ b/backend/src/main/kotlin/fr/gouv/dgampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPATargetRepository.kt
@@ -7,6 +7,7 @@ import fr.gouv.dgampa.rapportnav.domain.repositories.mission.target2.v2.ITargetR
 import fr.gouv.dgampa.rapportnav.infrastructure.database.model.mission.target2.v2.TargetModel
 import fr.gouv.dgampa.rapportnav.infrastructure.database.repositories.interfaces.mission.target2.v2.IDBTargetRepository
 import org.slf4j.LoggerFactory
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.dao.InvalidDataAccessApiUsageException
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
@@ -39,6 +40,13 @@ class JPATargetRepository(
             val saved = dbTargetRepository.save(target)
             logger.info("JPATargetRepository - Target saved successfully with id={}", target.id)
             saved
+        } catch (e: DataIntegrityViolationException) {
+            if (target.externalId != null) {
+                logger.warn("JPATargetRepository - duplicate external_id='{}', returning existing target", target.externalId)
+                return findByExternalId(target.externalId!!)
+                    ?: throw BackendInternalException(message = "Concurrent duplicate for external_id='${target.externalId}' but no existing row found", originalException = e)
+            }
+            throw BackendInternalException(message = "Unable to save target id='${target.id}'", originalException = e)
         } catch (e: InvalidDataAccessApiUsageException) {
             throw BackendUsageException(
                 code = BackendUsageErrorCode.COULD_NOT_SAVE_EXCEPTION,

--- a/backend/src/main/resources/db/migration/V1.2026.06.30.10.00__delete_duplicate_target2_external_id.sql
+++ b/backend/src/main/resources/db/migration/V1.2026.06.30.10.00__delete_duplicate_target2_external_id.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY external_id
+               ORDER BY created_at ASC NULLS LAST, id ASC
+           ) AS rn
+    FROM target_2
+    WHERE external_id IS NOT NULL
+),
+to_delete AS (
+    SELECT id FROM ranked WHERE rn > 1
+),
+controls_to_delete AS (
+    SELECT c.id AS control_id
+    FROM control_2 c
+    WHERE c.target_id IN (SELECT id FROM to_delete)
+),
+deleted_natinf AS (
+    DELETE FROM infraction_natinf_2
+    WHERE infraction_id IN (
+        SELECT i.id FROM infraction_2 i
+        WHERE i.control_id IN (SELECT control_id FROM controls_to_delete)
+    )
+    RETURNING infraction_id
+),
+deleted_infractions AS (
+    DELETE FROM infraction_2
+    WHERE control_id IN (SELECT control_id FROM controls_to_delete)
+    RETURNING id
+),
+deleted_controls AS (
+    DELETE FROM control_2
+    WHERE target_id IN (SELECT id FROM to_delete)
+    RETURNING target_id
+)
+DELETE FROM target_2
+WHERE id IN (SELECT id FROM to_delete);
+
+CREATE UNIQUE INDEX idx_target2_external_id_unique
+    ON target_2 (external_id)
+    WHERE external_id IS NOT NULL;
+
+COMMIT;

--- a/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPATargetRepositoryTest.kt
+++ b/backend/src/test/kotlin/fr/gouv/gmampa/rapportnav/infrastructure/database/repositories/mission/target2/v2/JPATargetRepositoryTest.kt
@@ -15,6 +15,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.dao.InvalidDataAccessApiUsageException
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
@@ -122,6 +123,29 @@ class JPATargetRepositoryTest {
             .thenThrow(InvalidDataAccessApiUsageException("Invalid data"))
 
         val exception = assertThrows<BackendUsageException> {
+            jpaTargetRepository.save(targetModel)
+        }
+        assertThat(exception.message).contains(targetId.toString())
+    }
+
+    @Test
+    fun `save should return existing target on duplicate external_id constraint violation`() {
+        val externalId = "ext-dup"
+        val existingTarget = TargetModel(id = UUID.randomUUID(), actionId = actionId, targetType = TargetType.VEHICLE, externalId = externalId)
+        val newTarget = TargetModel(id = UUID.randomUUID(), actionId = actionId, targetType = TargetType.VEHICLE, externalId = externalId)
+        `when`(dbTargetRepository.save(any<TargetModel>())).thenThrow(DataIntegrityViolationException("Unique index violation"))
+        `when`(dbTargetRepository.findByExternalId(externalId)).thenReturn(existingTarget)
+
+        val result = jpaTargetRepository.save(newTarget)
+
+        assertThat(result.id).isEqualTo(existingTarget.id)
+    }
+
+    @Test
+    fun `save should throw BackendInternalException on constraint violation without external_id`() {
+        `when`(dbTargetRepository.save(any<TargetModel>())).thenThrow(DataIntegrityViolationException("Constraint violation"))
+
+        val exception = assertThrows<BackendInternalException> {
             jpaTargetRepository.save(targetModel)
         }
         assertThat(exception.message).contains(targetId.toString())


### PR DESCRIPTION
- l'index permet d'éviter d'écrire les duplicats
- the fallback sur la save method, c'est pour avoir un fallback gracieux pour l'utilisateur pour pas se prendre des 500 quand pour des raisons inconnues plusieurs Targets essaient d'être insérées